### PR TITLE
Jenkins plugin - log an error if the app name mentioned is incorrect

### DIFF
--- a/contrastPluginConfig.xml
+++ b/contrastPluginConfig.xml
@@ -9,6 +9,7 @@
             <orgUuid>110a6669-82fb-4db3-8ad2-fef35b01371c</orgUuid>
             <teamServerUrl>http://localhost:19080/Contrast/api</teamServerUrl>
             <applicationName>WebGoat</applicationName>
+            <failOnWrongApplicationName>false</failOnWrongApplicationName>
         </com.aspectsecurity.contrast.contrastjenkins.TeamServerProfile>
     </teamServerProfiles>
 </com.aspectsecurity.contrast.contrastjenkins.ContrastPluginConfig_-ContrastPluginConfigDescriptor>

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -26,9 +26,11 @@ public class TeamServerProfile {
 
     private List<VulnerabilityType> vulnerabilityTypes;
 
+    private boolean failOnWrongApplicationName;
+
     @DataBoundConstructor
     public TeamServerProfile(String name, String username, String apiKey, String serviceKey,
-                             String teamServerUrl, String orgUuid, String applicationName) {
+                             String teamServerUrl, String orgUuid, String applicationName, boolean failOnWrongApplicationName) {
         this.name = name;
         this.username = username;
         this.apiKey = apiKey;
@@ -36,5 +38,6 @@ public class TeamServerProfile {
         this.teamServerUrl = teamServerUrl;
         this.orgUuid = orgUuid;
         this.applicationName = applicationName;
+        this.failOnWrongApplicationName = failOnWrongApplicationName;
     }
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -1,6 +1,9 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -69,6 +72,14 @@ public class VulnerabilityTrendRecorder extends Recorder {
         TeamServerProfile profile = getProfile();
 
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
+
+        String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), build.getParent().getDisplayName());
+        if (applicationId.equals("")) {
+            VulnerabilityTrendHelper.logMessage(listener, "Application with name '" + build.getParent().getDisplayName() + "' not found.");
+            if (profile.isFailOnWrongApplicationName()) {
+                throw new AbortException("Application with name '" + build.getParent().getDisplayName() + "' not found.");
+            }
+        }
 
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : conditions) {
@@ -234,6 +245,27 @@ public class VulnerabilityTrendRecorder extends Recorder {
         VulnerabilityTrendResult result = new VulnerabilityTrendResult(traceResult, severityResult);
 
         build.addAction(new VulnerabilityFrequencyAction(result, build));
+    }
+
+    private String getApplicationId(ContrastSDK sdk, String organizationUuid, String applicationName) {
+
+        Applications applications;
+
+        try {
+            applications = sdk.getApplications(organizationUuid);
+        } catch (IOException e) {
+            return "";
+        } catch (UnauthorizedException e) {
+            return "";
+        }
+
+        for(Application application: applications.getApplications()) {
+            if (applicationName.equals(application.getName())) {
+                return application.getId();
+            }
+        }
+
+        return "";
     }
 
 }

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
@@ -26,6 +26,10 @@
                         </f:entry>
                     </f:section>
 
+                    <f:entry title="Fail build if application is not found on TeamServer" help="/plugin/contrast-continuous-application-security/help-failOnWrongApplicationName.html" >
+                        <f:checkbox name="failOnWrongApplicationName" field="failOnWrongApplicationName" value="${profile.failOnWrongApplicationName}" checked="${profile.failOnWrongApplicationName}" />
+                    </f:entry>
+
                     <f:entry title="">
                         <f:validateButton title="${%Test TeamServer Connection}" progress="${%Testing Connection...}"
                                 method="testTeamServerConnection" with="username,apiKey,serviceKey,teamServerUrl" />

--- a/src/main/webapp/help-failOnWrongApplicationName.html
+++ b/src/main/webapp/help-failOnWrongApplicationName.html
@@ -1,0 +1,3 @@
+<div>
+    This option allows you to fail builds if the specified application name is not found on TeamServer.
+</div>


### PR DESCRIPTION
Now a message is logged if the specified application name does not exist in TeamServer.
Added an option to Jenkins TeamServer configuration to fail builds if the application name does not exist.