### PR TITLE
Regular Java io will not work on remote Jenkins slaves.

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
@@ -4,8 +4,10 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.IOUtils;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import lombok.Getter;
@@ -17,8 +19,8 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.util.Arrays;
 
 @Getter
 public class ContrastAgentStep extends AbstractStepImpl {
@@ -101,6 +103,9 @@ public class ContrastAgentStep extends AbstractStepImpl {
         @StepContextParameter
         private transient TaskListener taskListener;
 
+        @StepContextParameter
+        private transient FilePath filePath;
+
         @Inject
         private transient ContrastAgentStep step;
 
@@ -132,13 +137,24 @@ public class ContrastAgentStep extends AbstractStepImpl {
             }
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Saving agent to file.");
-
+            /* ddooley.  using FilePath instead of File.
+            *  Regular Java io will not work on remote Jenkins slaves.
+            *  The contrast.jar will not persist on the slave with java.io.File, probably due to how the Jenkins agent technology works.
+            *  It is better to use the Hudson libraries. */
             try {
-                // Write bytes to file
-                FileUtils.writeByteArrayToFile(agentFile, agent);
-            } catch (IOException e) {
+                filePath.child(step.getOutputDirectory()).mkdirs();
+                OutputStream outputStream = null;
+                InputStream inputStream = null;
+                try {
+                    outputStream = filePath.child(step.getOutputDirectory() + "/" + "contrast.jar").write();
+                    inputStream = new ByteArrayInputStream(agent);
+                    IOUtils.copy(inputStream,outputStream);
+                } finally {
+                    IOUtils.closeQuietly(outputStream);
+                }
+            } catch (Exception e) {
                 VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                throw new AbortException("Unable to save file to " + step.getOutputDirectory());
+                throw new AbortException("Unable to save file to " + step.getOutputDirectory() + " The exception message is " + e.getMessage() + " The stack trace is " + Arrays.toString(e.getStackTrace()));
             }
 
             return null;


### PR DESCRIPTION
Regular Java io will not work on remote Jenkins slaves.
The contrast.jar will not persist on the slave.
It is better to use the Hudson libraries