### PR TITLE
Contrast 21733

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
@@ -4,6 +4,7 @@ import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.Extension;
+import hudson.RelativePath;
 import hudson.model.AbstractProject;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -117,6 +118,20 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
             save();
 
             return true;
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillTeamServerProfileNameItems() {
+            return VulnerabilityTrendHelper.getProfileNames();
+        }
+
+        /**
+         * Fills the Threshold Category select drop down with vulnerability types for the configured profile.
+         *
+         * @return ListBoxModel filled with vulnerability types.
+         */
+        public ListBoxModel doFillThresholdVulnTypeItems(@QueryParameter("teamServerProfileName") final String teamServerProfileName) throws IOException {
+            return VulnerabilityTrendHelper.getVulnerabilityTypes(teamServerProfileName);
         }
 
         /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/GlobalThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/GlobalThresholdCondition.java
@@ -1,0 +1,77 @@
+package com.aspectsecurity.contrast.contrastjenkins;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class GlobalThresholdCondition {
+
+    private Integer thresholdCount;
+
+    private String thresholdSeverity;
+
+
+    private boolean autoRemediated;
+    private boolean confirmed;
+    private boolean suspicious;
+    private boolean notAProblem;
+    private boolean remediated;
+    private boolean reported;
+    private boolean fixed;
+    private boolean beingTracked;
+    private boolean untracked;
+
+    @DataBoundConstructor
+    public GlobalThresholdCondition(Integer thresholdCount, String thresholdSeverity, boolean autoRemediated,
+                                    boolean confirmed, boolean suspicious, boolean notAProblem, boolean remediated,
+                                    boolean reported, boolean fixed, boolean beingTracked, boolean untracked) {
+        this.thresholdCount = thresholdCount;
+        this.thresholdSeverity = thresholdSeverity;
+        this.autoRemediated = autoRemediated;
+        this.confirmed = confirmed;
+        this.suspicious = suspicious;
+        this.notAProblem = notAProblem;
+        this.remediated = remediated;
+        this.reported = reported;
+        this.fixed = fixed;
+        this.beingTracked = beingTracked;
+        this.untracked = untracked;
+    }
+
+    public List<String> getVulnerabilityStatuses() {
+        List<String> status = new ArrayList();
+        if (autoRemediated) {
+            status.add(Constants.VULNERABILITY_STATUS_AUTO_REMEDIATED);
+        }
+        if (confirmed) {
+            status.add(Constants.VULNERABILITY_STATUS_CONFIRMED);
+        }
+        if (suspicious) {
+            status.add(Constants.VULNERABILITY_STATUS_SUSPICIOUS);
+        }
+        if (notAProblem) {
+            status.add(Constants.VULNERABILITY_STATUS_NOT_A_PROBLEM);
+        }
+        if (remediated) {
+            status.add(Constants.VULNERABILITY_STATUS_REMEDIATED);
+        }
+        if (reported) {
+            status.add(Constants.VULNERABILITY_STATUS_REPORTED);
+        }
+        if (fixed) {
+            status.add(Constants.VULNERABILITY_STATUS_FIXED);
+        }
+        if (beingTracked) {
+            status.add(Constants.VULNERABILITY_STATUS_BEING_TRACKED);
+        }
+        if (untracked) {
+            status.add(Constants.VULNERABILITY_STATUS_UNTRACKED);
+        }
+        return status;
+    }
+}

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/GlobalThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/GlobalThresholdCondition.java
@@ -11,10 +11,13 @@ import java.util.List;
 @Setter
 public class GlobalThresholdCondition {
 
+    private String teamServerProfileName;
+
     private Integer thresholdCount;
 
     private String thresholdSeverity;
 
+    private String thresholdVulnType;
 
     private boolean autoRemediated;
     private boolean confirmed;
@@ -27,11 +30,14 @@ public class GlobalThresholdCondition {
     private boolean untracked;
 
     @DataBoundConstructor
-    public GlobalThresholdCondition(Integer thresholdCount, String thresholdSeverity, boolean autoRemediated,
+    public GlobalThresholdCondition(String teamServerProfileName, Integer thresholdCount, String thresholdSeverity, String thresholdVulnType, boolean autoRemediated,
                                     boolean confirmed, boolean suspicious, boolean notAProblem, boolean remediated,
                                     boolean reported, boolean fixed, boolean beingTracked, boolean untracked) {
+
+        this.teamServerProfileName = teamServerProfileName;
         this.thresholdCount = thresholdCount;
         this.thresholdSeverity = thresholdSeverity;
+        this.thresholdVulnType = thresholdVulnType;
         this.autoRemediated = autoRemediated;
         this.confirmed = confirmed;
         this.suspicious = suspicious;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -30,10 +30,12 @@ public class TeamServerProfile {
 
     private String vulnerableBuildResult;
 
+    private boolean allowGlobalThresholdConditionsOverride;
+
     @DataBoundConstructor
     public TeamServerProfile(String name, String username, String apiKey, String serviceKey, String orgUuid,
                              String teamServerUrl, String applicationName, boolean failOnWrongApplicationName,
-                             String vulnerableBuildResult) {
+                             String vulnerableBuildResult, boolean allowGlobalThresholdConditionsOverride) {
         this.name = name;
         this.username = username;
         this.apiKey = apiKey;
@@ -43,5 +45,6 @@ public class TeamServerProfile {
         this.applicationName = applicationName;
         this.failOnWrongApplicationName = failOnWrongApplicationName;
         this.vulnerableBuildResult = vulnerableBuildResult;
+        this.allowGlobalThresholdConditionsOverride = allowGlobalThresholdConditionsOverride;
     }
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -82,6 +82,31 @@ public class VulnerabilityTrendHelper {
 
     }
 
+    public static List<ThresholdCondition> getThresholdConditions(final List<ThresholdCondition> thresholdConditions,
+                                                                  final List<GlobalThresholdCondition> globalThresholdConditions) {
+        List<ThresholdCondition> newThresholdConditions = new ArrayList<>();
+
+
+        for (ThresholdCondition thresholdCondition: thresholdConditions) {
+            for (GlobalThresholdCondition globalThresholdCondition: globalThresholdConditions) {
+
+                ThresholdCondition newThresholdCondition = new ThresholdCondition(
+                        globalThresholdCondition.getThresholdCount(),
+                        globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(),
+                        thresholdCondition.getApplicationName(),globalThresholdCondition.isAutoRemediated(),
+                        globalThresholdCondition.isConfirmed(),globalThresholdCondition.isSuspicious(),
+                        globalThresholdCondition.isNotAProblem(),globalThresholdCondition.isRemediated(),
+                        globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
+                        globalThresholdCondition.isUntracked());
+
+                newThresholdConditions.add(newThresholdCondition);
+
+            }
+        }
+        return newThresholdConditions;
+
+    }
+
     /**
      * Helper method for logging messages.
      *

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -69,6 +69,19 @@ public class VulnerabilityTrendHelper {
         return null;
     }
 
+    public static List<GlobalThresholdCondition> getGlobalThresholdConditions(String profileName) {
+        final GlobalThresholdCondition[] globalThresholdConditions = new ContrastPluginConfig.ContrastPluginConfigDescriptor().getGlobalThresholdConditions();
+        List<GlobalThresholdCondition> globalThresholdConditionList = new ArrayList<>();
+
+        for (GlobalThresholdCondition globalThresholdCondition : globalThresholdConditions) {
+            if (profileName.equals(globalThresholdCondition.getTeamServerProfileName())) {
+                globalThresholdConditionList.add(globalThresholdCondition);
+            }
+        }
+        return globalThresholdConditionList;
+
+    }
+
     /**
      * Helper method for logging messages.
      *

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -82,6 +82,12 @@ public class VulnerabilityTrendHelper {
 
     }
 
+    /**
+     * Helper method for combining global threshold conditions and threshold conditions configured in jobs.
+     *
+     * @param thresholdConditions
+     * @param globalThresholdConditions
+     */
     public static List<ThresholdCondition> getThresholdConditions(final List<ThresholdCondition> thresholdConditions,
                                                                   final List<GlobalThresholdCondition> globalThresholdConditions) {
         List<ThresholdCondition> newThresholdConditions = new ArrayList<>();

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -22,6 +22,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 import java.io.IOException;
 import java.util.*;
@@ -46,6 +47,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
     public TeamServerProfile getProfile() {
         return VulnerabilityTrendHelper.getProfile(teamServerProfileName);
+    }
+
+    @JavaScriptMethod
+    public boolean isAllowGlobalThresholdConditionsOverride(String teamServerProfileName) {
+        return VulnerabilityTrendHelper.getProfile(teamServerProfileName).isAllowGlobalThresholdConditionsOverride();
     }
 
     @Override
@@ -76,8 +82,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
         }
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
-
-            System.out.println(condition);
 
             String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), condition.getApplicationName());
             if (applicationId.equals("")) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -66,12 +66,18 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
 
+
+        List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
+
+        List<ThresholdCondition> thresholdConditions = conditions;
+
+        if (!profile.isAllowGlobalThresholdConditionsOverride()) {
+            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+        }
         // iterate over conditions; fail on first
-        for (ThresholdCondition condition : conditions) {
+        for (ThresholdCondition condition : thresholdConditions) {
 
-            if (profile.isAllowGlobalThresholdConditionsOverride()) {
-
-            }
+            System.out.println(condition);
 
             String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), condition.getApplicationName());
             if (applicationId.equals("")) {
@@ -124,6 +130,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 }
             }
         }
+
 
         buildResult(resultTraces, build);
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -74,8 +74,12 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         List<ThresholdCondition> thresholdConditions = conditions;
 
-        if (!profile.isAllowGlobalThresholdConditionsOverride()) {
+        // if global threshold conditions cannot be overridden or the user does not want to override them
+        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
             thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+            if (thresholdConditions.isEmpty()) {
+                throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
+            }
         }
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -38,20 +38,17 @@ import java.util.*;
 public class VulnerabilityTrendRecorder extends Recorder {
     private List<ThresholdCondition> conditions;
     private String teamServerProfileName;
+    private boolean overrideGlobalThresholdConditions;
 
     @DataBoundConstructor
-    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName) {
+    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName, boolean overrideGlobalThresholdConditions) {
         this.conditions = conditions;
         this.teamServerProfileName = teamServerProfileName;
+        this.overrideGlobalThresholdConditions = overrideGlobalThresholdConditions;
     }
 
     public TeamServerProfile getProfile() {
         return VulnerabilityTrendHelper.getProfile(teamServerProfileName);
-    }
-
-    @JavaScriptMethod
-    public boolean isAllowGlobalThresholdConditionsOverride(String teamServerProfileName) {
-        return VulnerabilityTrendHelper.getProfile(teamServerProfileName).isAllowGlobalThresholdConditionsOverride();
     }
 
     @Override
@@ -172,6 +169,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
             load();
         }
 
+        @JavaScriptMethod
+        public boolean isAllowGlobalThresholdConditionsOverride(String teamServerProfileName) {
+            return VulnerabilityTrendHelper.getProfile(teamServerProfileName).isAllowGlobalThresholdConditionsOverride();
+        }
+
         @SuppressWarnings("unused")
         public ListBoxModel doFillTeamServerProfileNameItems() {
             return VulnerabilityTrendHelper.getProfileNames();
@@ -219,7 +221,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             save();
 
-            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"));
+            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"));
         }
 
         public void setConditions(List<ThresholdCondition> conditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -69,6 +69,10 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : conditions) {
 
+            if (profile.isAllowGlobalThresholdConditionsOverride()) {
+
+            }
+
             String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), condition.getApplicationName());
             if (applicationId.equals("")) {
                 VulnerabilityTrendHelper.logMessage(listener, "Application with name '" + condition.getApplicationName() + "' not found.");

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
@@ -61,12 +61,21 @@
         <f:entry description="Conditions for verifying your build">
             <f:repeatable var="globalThresholdCondition" items="${descriptor.globalThresholdConditions}">
                 <table width="100%">
+
+                    <f:entry title="TeamServer Profile">
+                        <f:select default="${globalThresholdCondition.teamServerProfileName}" field="teamServerProfileName"/>
+                    </f:entry>
+
                     <f:entry title="Count" help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
                         <f:number name="thresholdCount" field="thresholdCount" value="${globalThresholdCondition.thresholdCount}" default="0" clazz="required positive-number" />
                     </f:entry>
 
                     <f:entry title="Severity" help="/plugin/contrast-continuous-application-security/help-thresholdSeverity.html">
                         <f:select default="${globalThresholdCondition.thresholdSeverity}" field="thresholdSeverity"/>
+                    </f:entry>
+
+                    <f:entry title="Vulnerability Type" help="/plugin/contrast-continuous-application-security/help-thresholdVulnType.html">
+                        <f:select default="${globalThresholdCondition.thresholdVulnType}" field="thresholdVulnType"/>
                     </f:entry>
 
                     <f:entry title="Vulnerability statuses" help="/plugin/contrast-continuous-application-security/help-vulnerabilityStatus.html">

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
@@ -49,4 +49,59 @@
             </f:repeatable>
         </f:entry>
     </f:section>
+
+
+
+    <f:section title="Contrast Vulnerability Threshold Conditions">
+
+        <f:entry description="Conditions for verifying your build">
+            <f:repeatable var="globalThresholdCondition" items="${descriptor.globalThresholdConditions}">
+                <table width="100%">
+                    <f:entry title="Count" help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
+                        <f:number name="thresholdCount" field="thresholdCount" value="${globalThresholdCondition.thresholdCount}" default="0" clazz="required positive-number" />
+                    </f:entry>
+
+                    <f:entry title="Severity" help="/plugin/contrast-continuous-application-security/help-thresholdSeverity.html">
+                        <f:select default="${globalThresholdCondition.thresholdSeverity}" field="thresholdSeverity"/>
+                    </f:entry>
+
+                    <f:entry title="Vulnerability statuses" help="/plugin/contrast-continuous-application-security/help-vulnerabilityStatus.html">
+                        <f:checkbox title="Auto-Remediated" name="autoRemediated" field="autoRemediated" value="${globalThresholdCondition.autoRemediated}" checked="${globalThresholdCondition.autoRemediated}"/>
+                    </f:entry>
+
+                    <f:entry>
+                        <f:checkbox title="Not a Problem" name="notAProblem" field="notAProblem" value="${globalThresholdCondition.notAProblem}" checked="${globalThresholdCondition.notAProblem}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Fixed" name="fixed" field="fixed" value="${globalThresholdCondition.fixed}" checked="${globalThresholdCondition.fixed}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Confirmed" name="confirmed" field="confirmed" value="${globalThresholdCondition.confirmed}" checked="${globalThresholdCondition.confirmed}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Remediated" name="remediated" field="remediated" value="${globalThresholdCondition.remediated}" checked="${globalThresholdCondition.remediated}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Being Tracked" name="beingTracked" field="beingTracked" value="${globalThresholdCondition.beingTracked}" checked="${globalThresholdCondition.beingTracked}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Suspicious" name="suspicious" field="suspicious" value="${globalThresholdCondition.suspicious}" checked="${globalThresholdCondition.suspicious}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Reported" name="reported" field="reported" value="${globalThresholdCondition.reported}" checked="${globalThresholdCondition.reported}"/>
+                    </f:entry>
+                    <f:entry>
+                        <f:checkbox title="Untracked" name="untracked" field="untracked" value="${globalThresholdCondition.untracked}" checked="${globalThresholdCondition.untracked}"/>
+                    </f:entry>
+
+                    <f:entry title="">
+                        <div align="right">
+                            <f:repeatableDeleteButton/>
+                        </div>
+                    </f:entry>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
+
 </j:jelly>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
@@ -34,6 +34,10 @@
                         <f:checkbox title="Fail build if application is not found on TeamServer" name="failOnWrongApplicationName" field="failOnWrongApplicationName" value="${profile.failOnWrongApplicationName}" checked="${profile.failOnWrongApplicationName}" />
                     </f:entry>
 
+                    <f:entry help="/plugin/contrast-continuous-application-security/help-allowGlobalThresholdConditionsOverride.html" >
+                        <f:checkbox title="Allow global Contrast Vulnerability Threshold Conditions to be overridden in a Job configuration" name="allowGlobalThresholdConditionsOverride" field="allowGlobalThresholdConditionsOverride" value="${profile.allowGlobalThresholdConditionsOverride}" checked="${profile.allowGlobalThresholdConditionsOverride}" />
+                    </f:entry>
+
                     <f:entry title="">
                         <f:validateButton title="${%Test Contrast Connection}" progress="${%Testing Connection...}"
                                 method="testTeamServerConnection" with="username,apiKey,serviceKey,teamServerUrl" />

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -6,6 +6,11 @@
             <f:select/>
         </f:entry>
 
+        <f:entry>
+            <f:checkbox title="Override Global Threshold Conditions" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
+        </f:entry>
+
+
         <f:entry description="Conditions for verifying your build">
             <f:repeatable field="conditions">
                 <table width="100%">
@@ -69,20 +74,47 @@
         </f:entry>
     </f:section>
     <script>
-        var elements = document.getElementsByName("_.teamServerProfileName");
-        var teamServerProfileSelect = elements[0];
+        var overrideGlobalThresholdConditionsCheckboxElements =
+        document.getElementsByName("overrideGlobalThresholdConditions");
+        var teamServerProfileSelectElements = document.getElementsByName("_.teamServerProfileName");
 
-        if (teamServerProfileSelect != undefined) {
-            teamServerProfileSelect.onchange = function() {isAllowGlobalThresholdConditionsOverride(teamServerProfileSelect.value)};
-        }
+        <!-- -->
+        var thresholdCountElements = document.getElementsByName("thresholdCount");
+        var thresholdSeverityElements = document.getElementsByName("_.thresholdSeverity");
+        var thresholdVulnTypeElements = document.getElementsByName("_.thresholdVulnType");
+        var autoRemediatedElements = document.getElementsByName("autoRemediated");
+        var notAProblemElements = document.getElementsByName("notAProblem");
+        var fixedElements = document.getElementsByName("fixed");
+        var confirmedElements = document.getElementsByName("confirmed");
+        var remediatedElements = document.getElementsByName("remediated");
+        var beingTrackedElements = document.getElementsByName("beingTracked");
+        var suspiciousElements = document.getElementsByName("suspicious");
+        var reportedElements = document.getElementsByName("reported");
+        var untrackedElements = document.getElementsByName("untracked");
 
-        var publisher = document.querySelector("div[descriptorid$='.VulnerabilityTrendRecorder']");
-        <!--console.log(publisher);-->
-
-        <!---->
+        var dynamicElements = [];
+        dynamicElements.push(thresholdCountElements);
+        dynamicElements.push(thresholdSeverityElements);
+        dynamicElements.push(thresholdVulnTypeElements);
+        dynamicElements.push(autoRemediatedElements);
+        dynamicElements.push(notAProblemElements);
+        dynamicElements.push(fixedElements);
+        dynamicElements.push(confirmedElements);
+        dynamicElements.push(remediatedElements);
+        dynamicElements.push(beingTrackedElements);
+        dynamicElements.push(suspiciousElements);
+        dynamicElements.push(reportedElements);
+        dynamicElements.push(untrackedElements);
+        <!--  -->
 
         var observer = new MutationObserver(function(mutations) {
-            <!--console.log("mutations");-->
+
+            if (teamServerProfileSelectElements[0] != undefined &amp;&amp; teamServerProfileSelectElements[0].onchange == null){
+                teamServerProfileSelectElements[0].onchange = function() {isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value);};
+            }
+            if (overrideGlobalThresholdConditionsCheckboxElements[0] != undefined &amp;&amp; overrideGlobalThresholdConditionsCheckboxElements[0].onchange == null) {
+                overrideGlobalThresholdConditionsCheckboxElements[0].onchange = function() { isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value); };
+            }
             mutations.forEach(function(mutation) {
                 if (mutation.addedNodes.length > 0) {
                     console.log(mutation);
@@ -93,15 +125,32 @@
         observer.observe(document.querySelector("form[name=config]"), { childList: true, subtree: true });
         <!---->
 
-        <!-- Create a proxy variable to access VulnerabilityTrendRecorder.java class -->
-        var vulnerabilityTrendRecorder =
-        <st:bind value="${instance}"/>
+        <!-- Create a proxy variable to access the descriptor of VulnerabilityTrendRecorder.java class -->
+        var descriptorImpl =
+        <st:bind value="${descriptor}"/>
 
         <!-- Checks if 'isAllowGlobalThresholdConditionsOverride' variable is set to true in the selected TeamServer profile -->
         function isAllowGlobalThresholdConditionsOverride(teamServerProfileName) {
-            vulnerabilityTrendRecorder.isAllowGlobalThresholdConditionsOverride(teamServerProfileName, function(t){
+            descriptorImpl.isAllowGlobalThresholdConditionsOverride(teamServerProfileName, function(t){
                 if (t.responseObject()) {
+                    overrideGlobalThresholdConditionsCheckboxElements[0].disabled = false;
+
+                    for (var i = 0; i &lt; dynamicElements.length; i++) {
+                        for (var j = 0; j &lt; dynamicElements[i].length; j++) {
+                            dynamicElements[i][j].disabled = !overrideGlobalThresholdConditionsCheckboxElements[0].checked;
+                        }
+                    }
+
+
                 } else {
+                    overrideGlobalThresholdConditionsCheckboxElements[0].disabled = true;
+                    overrideGlobalThresholdConditionsCheckboxElements[0].checked = false;
+
+                    for (var i = 0; i &lt; dynamicElements.length; i++) {
+                        for (var j = 0; j &lt; dynamicElements[i].length; j++) {
+                            dynamicElements[i][j].disabled = true;
+                        }
+                    }
                 }
             });
         }

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -6,8 +6,6 @@
             <f:select/>
         </f:entry>
 
-        <j:set var="vulnerabilityTrendRecorderInstance" value="${instance}"/>
-
         <f:entry description="Conditions for verifying your build">
             <f:repeatable field="conditions">
                 <table width="100%">
@@ -71,54 +69,43 @@
         </f:entry>
     </f:section>
     <script>
-        var thresholdCountElements = document.getElementsByName("thresholdCount");
-        var thresholdSeverityElements = document.getElementsByName("_.thresholdSeverity");
-        var thresholdVulnTypeElements = document.getElementsByName("_.thresholdVulnType");
-        var autoRemediatedElements = document.getElementsByName("autoRemediated");
-        var notAProblemElements = document.getElementsByName("notAProblem");
-        var fixedElements = document.getElementsByName("fixed");
-        var confirmedElements = document.getElementsByName("confirmed");
-        var remediatedElements = document.getElementsByName("remediated");
-        var beingTrackedElements = document.getElementsByName("beingTracked");
-        var suspiciousElements = document.getElementsByName("suspicious");
-        var reportedElements = document.getElementsByName("reported");
-        var untrackedElements = document.getElementsByName("untracked");
-
-        var dynamicElements = [];
-        dynamicElements.push(thresholdCountElements);
-        dynamicElements.push(thresholdSeverityElements);
-        dynamicElements.push(thresholdVulnTypeElements);
-        dynamicElements.push(autoRemediatedElements);
-        dynamicElements.push(notAProblemElements);
-        dynamicElements.push(fixedElements);
-        dynamicElements.push(confirmedElements);
-        dynamicElements.push(remediatedElements);
-        dynamicElements.push(beingTrackedElements);
-        dynamicElements.push(suspiciousElements);
-        dynamicElements.push(reportedElements);
-        dynamicElements.push(untrackedElements);
-
-
-
         var elements = document.getElementsByName("_.teamServerProfileName");
         var teamServerProfileSelect = elements[0];
-        teamServerProfileSelect.onchange = function() {isAllowGlobalThresholdConditionsOverride()};
 
-        var obj =
+        if (teamServerProfileSelect != undefined) {
+            teamServerProfileSelect.onchange = function() {isAllowGlobalThresholdConditionsOverride(teamServerProfileSelect.value)};
+        }
+
+        var publisher = document.querySelector("div[descriptorid$='.VulnerabilityTrendRecorder']");
+        <!--console.log(publisher);-->
+
+        <!---->
+
+        var observer = new MutationObserver(function(mutations) {
+            <!--console.log("mutations");-->
+            mutations.forEach(function(mutation) {
+                if (mutation.addedNodes.length > 0) {
+                    console.log(mutation);
+                }
+            });
+        });
+
+        observer.observe(document.querySelector("form[name=config]"), { childList: true, subtree: true });
+        <!---->
+
+        <!-- Create a proxy variable to access VulnerabilityTrendRecorder.java class -->
+        var vulnerabilityTrendRecorder =
         <st:bind value="${instance}"/>
 
-        function isAllowGlobalThresholdConditionsOverride() {
-        obj.isAllowGlobalThresholdConditionsOverride(teamServerProfileSelect.value, function(t){
-
-        if (t.responseObject()) {
-
-        } else {
-
-
+        <!-- Checks if 'isAllowGlobalThresholdConditionsOverride' variable is set to true in the selected TeamServer profile -->
+        function isAllowGlobalThresholdConditionsOverride(teamServerProfileName) {
+            vulnerabilityTrendRecorder.isAllowGlobalThresholdConditionsOverride(teamServerProfileName, function(t){
+                if (t.responseObject()) {
+                } else {
+                }
+            });
         }
-        console.log(t.responseObject());
-        });
-        }
+
     </script>
 
 </j:jelly>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -6,9 +6,16 @@
             <f:select/>
         </f:entry>
 
+        <j:set var="vulnerabilityTrendRecorderInstance" value="${instance}"/>
+
         <f:entry description="Conditions for verifying your build">
             <f:repeatable field="conditions">
                 <table width="100%">
+                    <f:entry title="Application Name"
+                             help="/plugin/contrast-continuous-application-security/help-applicationName.html">
+                        <f:textbox name="applicationName" field="applicationName" default="${it.displayName}"/>
+                    </f:entry>
+
                     <f:entry title="Count" field="thresholdCount"
                              help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
                         <f:number name="thresholdCount" field="thresholdCount" default="0"
@@ -23,11 +30,6 @@
                     <f:entry title="Vulnerability Type" field="thresholdVulnType"
                              help="/plugin/contrast-continuous-application-security/help-thresholdVulnType.html">
                         <f:select/>
-                    </f:entry>
-
-                    <f:entry title="Application Name"
-                             help="/plugin/contrast-continuous-application-security/help-applicationName.html">
-                        <f:textbox name="applicationName" field="applicationName" default="${it.displayName}"/>
                     </f:entry>
 
                     <f:entry title="Vulnerability statuses" help="/plugin/contrast-continuous-application-security/help-vulnerabilityStatus.html">

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -115,9 +115,10 @@
             if (overrideGlobalThresholdConditionsCheckboxElements[0] != undefined &amp;&amp; overrideGlobalThresholdConditionsCheckboxElements[0].onchange == null) {
                 overrideGlobalThresholdConditionsCheckboxElements[0].onchange = function() { isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value); };
             }
+
             mutations.forEach(function(mutation) {
-                if (mutation.addedNodes.length > 0) {
-                    console.log(mutation);
+                if (mutation.addedNodes.length > 0 &amp;&amp; mutation.target.className == "repeated-container") {
+                    isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value);
                 }
             });
         });
@@ -137,7 +138,12 @@
 
                     for (var i = 0; i &lt; dynamicElements.length; i++) {
                         for (var j = 0; j &lt; dynamicElements[i].length; j++) {
-                            dynamicElements[i][j].disabled = !overrideGlobalThresholdConditionsCheckboxElements[0].checked;
+                            if (overrideGlobalThresholdConditionsCheckboxElements[0].checked) {
+                                dynamicElements[i][j].parentNode.parentNode.style.display = "";
+                            } else {
+                                dynamicElements[i][j].parentNode.parentNode.style.display = "none";
+                            }
+
                         }
                     }
 
@@ -148,7 +154,7 @@
 
                     for (var i = 0; i &lt; dynamicElements.length; i++) {
                         for (var j = 0; j &lt; dynamicElements[i].length; j++) {
-                            dynamicElements[i][j].disabled = true;
+                            dynamicElements[i][j].parentNode.parentNode.style.display = "none";
                         }
                     }
                 }

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
 
     <f:section title="Vulnerability Threshold Conditions">
         <f:entry title="TeamServer Profile" field="teamServerProfileName">
@@ -70,4 +70,55 @@
             </f:repeatable>
         </f:entry>
     </f:section>
+    <script>
+        var thresholdCountElements = document.getElementsByName("thresholdCount");
+        var thresholdSeverityElements = document.getElementsByName("_.thresholdSeverity");
+        var thresholdVulnTypeElements = document.getElementsByName("_.thresholdVulnType");
+        var autoRemediatedElements = document.getElementsByName("autoRemediated");
+        var notAProblemElements = document.getElementsByName("notAProblem");
+        var fixedElements = document.getElementsByName("fixed");
+        var confirmedElements = document.getElementsByName("confirmed");
+        var remediatedElements = document.getElementsByName("remediated");
+        var beingTrackedElements = document.getElementsByName("beingTracked");
+        var suspiciousElements = document.getElementsByName("suspicious");
+        var reportedElements = document.getElementsByName("reported");
+        var untrackedElements = document.getElementsByName("untracked");
+
+        var dynamicElements = [];
+        dynamicElements.push(thresholdCountElements);
+        dynamicElements.push(thresholdSeverityElements);
+        dynamicElements.push(thresholdVulnTypeElements);
+        dynamicElements.push(autoRemediatedElements);
+        dynamicElements.push(notAProblemElements);
+        dynamicElements.push(fixedElements);
+        dynamicElements.push(confirmedElements);
+        dynamicElements.push(remediatedElements);
+        dynamicElements.push(beingTrackedElements);
+        dynamicElements.push(suspiciousElements);
+        dynamicElements.push(reportedElements);
+        dynamicElements.push(untrackedElements);
+
+
+
+        var elements = document.getElementsByName("_.teamServerProfileName");
+        var teamServerProfileSelect = elements[0];
+        teamServerProfileSelect.onchange = function() {isAllowGlobalThresholdConditionsOverride()};
+
+        var obj =
+        <st:bind value="${instance}"/>
+
+        function isAllowGlobalThresholdConditionsOverride() {
+        obj.isAllowGlobalThresholdConditionsOverride(teamServerProfileSelect.value, function(t){
+
+        if (t.responseObject()) {
+
+        } else {
+
+
+        }
+        console.log(t.responseObject());
+        });
+        }
+    </script>
+
 </j:jelly>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -78,7 +78,7 @@
         document.getElementsByName("overrideGlobalThresholdConditions");
         var teamServerProfileSelectElements = document.getElementsByName("_.teamServerProfileName");
 
-        <!-- -->
+        <!-- All the fields of a Threshold Condition except the application name will be hidden if the global threshold conditions are used -->
         var thresholdCountElements = document.getElementsByName("thresholdCount");
         var thresholdSeverityElements = document.getElementsByName("_.thresholdSeverity");
         var thresholdVulnTypeElements = document.getElementsByName("_.thresholdVulnType");
@@ -105,14 +105,16 @@
         dynamicElements.push(suspiciousElements);
         dynamicElements.push(reportedElements);
         dynamicElements.push(untrackedElements);
-        <!--  -->
 
+        <!-- When Threshold Conditions are added to the page, observer hides all of their fields except the app name if needed -->
         var observer = new MutationObserver(function(mutations) {
 
             if (teamServerProfileSelectElements[0] != undefined &amp;&amp; teamServerProfileSelectElements[0].onchange == null){
+                <!-- Hide fields if a teamserver profile selected with isAllowGlobalThresholdConditionsOverride variable set to false  -->
                 teamServerProfileSelectElements[0].onchange = function() {isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value);};
             }
             if (overrideGlobalThresholdConditionsCheckboxElements[0] != undefined &amp;&amp; overrideGlobalThresholdConditionsCheckboxElements[0].onchange == null) {
+                <!-- Hide fields if the user chooses to use global conditions  -->
                 overrideGlobalThresholdConditionsCheckboxElements[0].onchange = function() { isAllowGlobalThresholdConditionsOverride(teamServerProfileSelectElements[0].value); };
             }
 

--- a/src/main/webapp/help-allowGlobalThresholdConditionsOverride.html
+++ b/src/main/webapp/help-allowGlobalThresholdConditionsOverride.html
@@ -1,0 +1,3 @@
+<div>
+    This option allows you to choose if the global Contrast Vulnerability Threshold Conditions can be overridden in a job configuration.
+</div>

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -63,7 +63,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test"));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -75,7 +75,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -111,7 +111,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test"));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -123,7 +123,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -159,7 +159,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test"));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -171,7 +171,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -209,7 +209,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test"));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -221,7 +221,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -270,7 +270,7 @@ public class VulnerabilityTrendRecorderTest {
 
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test"));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -282,7 +282,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -74,7 +74,7 @@ public class VulnerabilityTrendStepTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -105,7 +105,7 @@ public class VulnerabilityTrendStepTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString());
+                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 


### PR DESCRIPTION
Added functionality allowing to add global vulnerability policy.
To test:
- Create a new teamserver profile.
- Uncheck the checkbox "Allow global Contrast Vulnerability Threshold Conditions to be overridden in a Job configuration".
- Click "Apply" to save the profile,
- Add a new global Vulnerability Threshold Condition for the created profile.
- Create a new Job with the Contrast post-build step and build it.
- Make sure that the job console logs contain the correct global threshold condition.

![global policy](https://user-images.githubusercontent.com/18661283/42402421-448fe130-8140-11e8-80b6-ea2342cd80f6.png)
![job policy use global conditions](https://user-images.githubusercontent.com/18661283/42402422-44b23096-8140-11e8-8bc1-8c2382ca4408.png)
![job policy](https://user-images.githubusercontent.com/18661283/42402423-44d7cbbc-8140-11e8-9d59-b82ba710582f.png)
