### PR TITLE
CONTRAST-25849

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
@@ -11,4 +11,7 @@ public final class Constants {
     public static final String VULNERABILITY_STATUS_BEING_TRACKED = "Being+Tracked";
     public static final String VULNERABILITY_STATUS_UNTRACKED = "Untracked";
     public static final String VULNERABILITY_STATUS_NOT_A_PROBLEM = "NotAProblem";
+
+    public static final int defaultAppVersionTagFormat = 1;
+    public static final int hierarchicalAppVersionTagFormat = 2;
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
@@ -12,6 +12,6 @@ public final class Constants {
     public static final String VULNERABILITY_STATUS_UNTRACKED = "Untracked";
     public static final String VULNERABILITY_STATUS_NOT_A_PROBLEM = "NotAProblem";
 
-    public static final int defaultAppVersionTagFormat = 1;
-    public static final int hierarchicalAppVersionTagFormat = 2;
+    public static final int DEFAULT_APP_VERSION_TAG_FORMAT = 1;
+    public static final int HIERARCHICAL_APP_VERSION_TAG_FORMAT = 2;
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -263,6 +263,10 @@ public class VulnerabilityTrendHelper {
         return applicationName + "-" + build.getNumber();
     }
 
+    public static String buildAppVersionTagHierarchical(Run<?, ?> build, String applicationName) {
+        return applicationName + "-" + build.getParent().getDisplayName() + "-" + build.getNumber();
+    }
+
     /**
      * Number of traces by severity
      *

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -37,8 +37,6 @@ import java.util.*;
 @Setter
 public class VulnerabilityTrendRecorder extends Recorder {
 
-    private static final int hierarchicalAppVersionTagFormat = 2;
-
     private List<ThresholdCondition> conditions;
     private String teamServerProfileName;
     private boolean overrideGlobalThresholdConditions;
@@ -109,7 +107,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 String appVersionTag = "";
-                if (appVersionTagFormat == hierarchicalAppVersionTagFormat) {
+                if (appVersionTagFormat == Constants.hierarchicalAppVersionTagFormat) {
                     appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
                 } else {
                     appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -124,7 +124,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     filterForm.setStatus(condition.getVulnerabilityStatuses());
                 }
 
-                System.out.println(filterForm);
                 traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
             } catch (Exception e) {
                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
@@ -240,7 +239,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             save();
 
-            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"), Integer.valueOf((String) json.get("appVersionTagFormat")));
+            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"), Integer.parseInt((String) json.get("appVersionTagFormat")));
         }
 
         public void setConditions(List<ThresholdCondition> conditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -36,15 +36,21 @@ import java.util.*;
 @Getter
 @Setter
 public class VulnerabilityTrendRecorder extends Recorder {
+
+    private static final int hierarchicalAppVersionTagFormat = 2;
+
     private List<ThresholdCondition> conditions;
     private String teamServerProfileName;
     private boolean overrideGlobalThresholdConditions;
+    private int appVersionTagFormat;
+
 
     @DataBoundConstructor
-    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName, boolean overrideGlobalThresholdConditions) {
+    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName, boolean overrideGlobalThresholdConditions, int appVersionTagFormat) {
         this.conditions = conditions;
         this.teamServerProfileName = teamServerProfileName;
         this.overrideGlobalThresholdConditions = overrideGlobalThresholdConditions;
+        this.appVersionTagFormat = appVersionTagFormat;
     }
 
     public TeamServerProfile getProfile() {
@@ -96,7 +102,15 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             try {
                 TraceFilterForm filterForm = new TraceFilterForm();
-                filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName())));
+
+                String appVersionTag = "";
+                if (appVersionTagFormat == hierarchicalAppVersionTagFormat) {
+                    appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                } else {
+                    appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
+                }
+
+                filterForm.setAppVersionTags(Collections.singletonList(appVersionTag));
 
                 if (condition.getThresholdSeverity() != null) {
                     filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(condition.getThresholdSeverity()));
@@ -110,6 +124,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     filterForm.setStatus(condition.getVulnerabilityStatuses());
                 }
 
+                System.out.println(filterForm);
                 traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
             } catch (Exception e) {
                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
@@ -225,7 +240,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             save();
 
-            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"));
+            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"), Integer.valueOf((String) json.get("appVersionTagFormat")));
         }
 
         public void setConditions(List<ThresholdCondition> conditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -107,7 +107,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 String appVersionTag = "";
-                if (appVersionTagFormat == Constants.hierarchicalAppVersionTagFormat) {
+                if (appVersionTagFormat == Constants.HIERARCHICAL_APP_VERSION_TAG_FORMAT) {
                     appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
                 } else {
                     appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -60,14 +60,21 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setApplicationName(String applicationName) { this.applicationName = applicationName; }
 
+    private int appVersionTagFormat;
+
+    @DataBoundSetter
+    public void setAppVersionTagFormat(int appVersionTagFormat) {
+        this.appVersionTagFormat = appVersionTagFormat;
+    }
 
     @DataBoundConstructor
-    public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationName) {
+    public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationName, int appVersionTagFormat) {
         this.profile = profile;
         this.count = count;
         this.rule = rule;
         this.severity = severity;
         this.applicationName = applicationName;
+        this.appVersionTagFormat = appVersionTagFormat;
     }
 
     // Used to build the new instance
@@ -145,6 +152,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 step.setApplicationName((String) applicationName);
             }
 
+            if (arguments.containsKey("appVersionTagFormat")) {
+                Object appVersionTagFormat = arguments.get("appVersionTagFormat");
+
+                step.setAppVersionTagFormat((int) appVersionTagFormat);
+            }
+
             return step;
         }
 
@@ -190,6 +203,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 step.setApplicationName(getBuildName());
             }
 
+            if (step.getAppVersionTagFormat() == 0) {
+                step.setAppVersionTagFormat(Constants.defaultAppVersionTagFormat);
+            }
+
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationName());
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
@@ -212,7 +229,11 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 if (step.getApplicationName() != null) {
-                    filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName())));
+                    if (step.getAppVersionTagFormat() == Constants.hierarchicalAppVersionTagFormat) {
+                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName())));
+                    } else {
+                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName())));
+                    }
                 }
 
                 if (step.getSeverity() != null) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -204,7 +204,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             }
 
             if (step.getAppVersionTagFormat() == 0) {
-                step.setAppVersionTagFormat(Constants.defaultAppVersionTagFormat);
+                step.setAppVersionTagFormat(Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
             }
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationName());
@@ -229,7 +229,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 if (step.getApplicationName() != null) {
-                    if (step.getAppVersionTagFormat() == Constants.hierarchicalAppVersionTagFormat) {
+                    if (step.getAppVersionTagFormat() == Constants.HIERARCHICAL_APP_VERSION_TAG_FORMAT) {
                         filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName())));
                     } else {
                         filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName())));

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -6,6 +6,15 @@
             <f:select/>
         </f:entry>
 
+        <f:entry title="Application version tag format" field="appVersionTagFormat">
+            <f:entry>
+                <f:radio name="appVersionTagFormat" title="applicationName-buildNumber" value="1" checked="true" />
+            </f:entry>
+            <f:entry>
+                <f:radio name="appVersionTagFormat" title="applicationName-buildName-buildNumber" value="2" checked="${instance.appVersionTagFormat == 2}" />
+            </f:entry>
+        </f:entry>
+
         <f:entry>
             <f:checkbox title="Override Global Threshold Conditions" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
         </f:entry>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -6,11 +6,11 @@
             <f:select/>
         </f:entry>
 
-        <f:entry title="Application version tag format" field="appVersionTagFormat">
+        <f:entry title="Application version tag format" field="appVersionTagFormat" >
             <f:entry>
                 <f:radio name="appVersionTagFormat" title="applicationName-buildNumber" value="1" checked="true" />
             </f:entry>
-            <f:entry>
+            <f:entry help="/plugin/contrast-continuous-application-security/help-appVersionTagFormat.html">
                 <f:radio name="appVersionTagFormat" title="applicationName-buildName-buildNumber" value="2" checked="${instance.appVersionTagFormat == 2}" />
             </f:entry>
         </f:entry>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
@@ -20,5 +20,10 @@
         <f:entry title="Vulnerability Type" field="rule" help="/plugin/contrast-continuous-application-security/help-thresholdVulnType.html">
             <f:select/>
         </f:entry>
+
+        <f:entry title="Application Version Tag Format" field="appVersionTagFormat" help="/plugin/contrast-continuous-application-security/help-appVersionTagFormat.html">
+            <f:textbox field="appVersionTagFormat"/>
+        </f:entry>
+
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
@@ -3,6 +3,6 @@
 
     Usage Example: <br>
     <code>
-        contrastVerification profile: 'Localhost', applicationName: WebGoat, count: 10, rule: xss, severity: High
+        contrastVerification profile: 'Localhost', applicationName: WebGoat, count: 10, rule: xss, severity: High, appVersionTagFormat: 1
     </code>
 </div>

--- a/src/main/webapp/help-appVersionTagFormat.html
+++ b/src/main/webapp/help-appVersionTagFormat.html
@@ -1,0 +1,3 @@
+<div>
+    appVersionTag format to use to filter vulnerabilities
+</div>

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -2,6 +2,8 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
+import hudson.model.Job;
+import hudson.model.Run;
 import junit.framework.TestCase;
 import org.junit.Test;
 
@@ -51,5 +53,24 @@ public class VulnerabilityTrendHelperTest extends TestCase {
 
         String info = VulnerabilityTrendHelper.getVulnerabilityInfoString(null);
         assertEquals("", info);
+    }
+
+    public void testBuildAppVersionTagHierarchical() {
+        String parentDisplayName = "project";
+        int buildNumber = 1;
+        String applicationName = "NodeTestBench";
+        String appVersionTagActual = applicationName + "-" + parentDisplayName + "-" + buildNumber;
+
+        Run<?, ?> build = mock(Run.class);
+
+        Job parent = mock(Job.class);
+
+        when(build.getParent()).thenReturn(parent);
+
+        when(parent.getDisplayName()).thenReturn(parentDisplayName);
+        when(build.getNumber()).thenReturn(buildNumber);
+
+        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationName);
+        assertEquals(appVersionTag, appVersionTagActual);
     }
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -63,7 +63,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -111,7 +111,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -159,7 +159,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true, 1));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -209,7 +209,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -270,7 +270,7 @@ public class VulnerabilityTrendRecorderTest {
 
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -7,9 +7,7 @@ import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Result;
+import hudson.model.*;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,7 +61,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -75,7 +74,8 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", "Jenkins", false,
+                Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -111,7 +111,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -123,7 +124,8 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", "Jenkins", false,
+                Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -159,7 +161,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true, 1));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -171,7 +174,8 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", "Jenkins", false,
+                Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -209,7 +213,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -221,7 +226,8 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", "Jenkins",
+                false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -270,7 +276,8 @@ public class VulnerabilityTrendRecorderTest {
 
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions, "test", true,1));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -282,7 +289,8 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", "Jenkins", false,
+                Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -313,6 +321,65 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
+
+        assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
+    }
+
+
+    @Test
+    public void testSuccessfulBuildAppVersionTag() throws Exception {
+
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All",
+                "WebGoat", true, true, true, true, true,
+                true,true, true,true);
+        conditions.add(thresholdCondition);
+        int buildNumber = 1;
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        final Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(0);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
+                "www.google.com", "org-uuid", "Jenkins", false,
+                Result.FAILURE.toString(), true);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+
+        Applications applications = mock(Applications.class);
+        Application application = mock(Application.class);
+        when(application.getId()).thenReturn("test");
+        when(application.getName()).thenReturn("test");
+
+        List<Application> apps = new ArrayList<>();
+        apps.add(application);
+
+        when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
+            public Traces answer(InvocationOnMock invocationOnMock) throws Throwable {
+                TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
+
+//                traceFilterForm.getAppVersionTags().get(0).equals();
+
+                return tracesMock;
+            }
+        });
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(buildNumber);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -29,7 +30,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, VulnerabilityTrendRecorder.class, VulnerabilityTrendHelper.class})
@@ -48,6 +48,7 @@ public class VulnerabilityTrendRecorderTest {
         PowerMockito.mockStatic(VulnerabilityTrendHelper.class);
 
         when(jenkins.getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class)).thenReturn(vulnerabilityTrendRecorderDescriptor);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
     }
 
     @Test
@@ -61,10 +62,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
-
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -83,9 +82,6 @@ public class VulnerabilityTrendRecorderTest {
         Application application = mock(Application.class);
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
-
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
 
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
@@ -111,10 +107,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
-
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(10);
@@ -133,9 +127,6 @@ public class VulnerabilityTrendRecorderTest {
         Application application = mock(Application.class);
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
-
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
 
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
@@ -161,10 +152,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true, Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
-
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -183,9 +172,6 @@ public class VulnerabilityTrendRecorderTest {
         Application application = mock(Application.class);
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
-
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
 
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
@@ -213,10 +199,8 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
-
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -236,12 +220,9 @@ public class VulnerabilityTrendRecorderTest {
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
 
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
-
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
-            public Traces answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Traces answer(InvocationOnMock invocationOnMock) {
                 TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
                 Assert.assertNull(traceFilterForm.getStatus());
                 return tracesMock;
@@ -268,7 +249,7 @@ public class VulnerabilityTrendRecorderTest {
         when(thresholdCondition.getThresholdSeverity()).thenReturn("test");
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
 
-        List<String> status = new ArrayList();
+        ArrayList<String> status = new ArrayList<>();
         status.add(Constants.VULNERABILITY_STATUS_AUTO_REMEDIATED);
         status.add(Constants.VULNERABILITY_STATUS_CONFIRMED);
         status.add(Constants.VULNERABILITY_STATUS_SUSPICIOUS);
@@ -276,10 +257,8 @@ public class VulnerabilityTrendRecorderTest {
 
         conditions.add(thresholdCondition);
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
-
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true,Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -299,12 +278,9 @@ public class VulnerabilityTrendRecorderTest {
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
 
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
-
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
-            public Traces answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Traces answer(InvocationOnMock invocationOnMock) {
                 TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
                 Assert.assertNotNull(traceFilterForm.getStatus());
                 Assert.assertEquals(traceFilterForm.getStatus().size(), 3);
@@ -330,16 +306,18 @@ public class VulnerabilityTrendRecorderTest {
     public void testSuccessfulBuildAppVersionTag() throws Exception {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
+        final String appName = "WebGoat";
+        final int buildNumber = 1;
+        final String buildParentDisplayName = "Project";
         ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All",
-                "WebGoat", true, true, true, true, true,
+                appName, true, true, true, true, true,
                 true,true, true,true);
         conditions.add(thresholdCondition);
-        int buildNumber = 1;
 
-        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = spy(new VulnerabilityTrendRecorder(conditions,
-                "test", true, Constants.DEFAULT_APP_VERSION_TAG_FORMAT));
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.HIERARCHICAL_APP_VERSION_TAG_FORMAT);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -359,21 +337,22 @@ public class VulnerabilityTrendRecorderTest {
         when(application.getId()).thenReturn("test");
         when(application.getName()).thenReturn("test");
 
-        List<Application> apps = new ArrayList<>();
-        apps.add(application);
-
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
-            public Traces answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Traces answer(InvocationOnMock invocationOnMock) {
                 TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
-
-//                traceFilterForm.getAppVersionTags().get(0).equals();
-
+                Assert.assertEquals(traceFilterForm.getAppVersionTags().get(0), appName + "-" + buildParentDisplayName + "-" + buildNumber);
                 return tracesMock;
             }
         });
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        AbstractProject<?, ?> parent = mock(AbstractProject.class);
+
+        when(parent.getDisplayName()).thenReturn(buildParentDisplayName);
+
+        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -55,7 +55,7 @@ public class VulnerabilityTrendStepTest {
     @Test
     public void testSuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
-        stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat");
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", 1);
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -86,7 +86,7 @@ public class VulnerabilityTrendStepTest {
     @Test(expected = AbortException.class)
     public void testUnsuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
-        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat");
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat",1);
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -55,7 +55,7 @@ public class VulnerabilityTrendStepTest {
     @Test
     public void testSuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
-        stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", 1);
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -86,7 +86,7 @@ public class VulnerabilityTrendStepTest {
     @Test(expected = AbortException.class)
     public void testUnsuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
-        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat",1);
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat",Constants.DEFAULT_APP_VERSION_TAG_FORMAT);
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 


### PR DESCRIPTION
Now users can choose which type of appVersionTag format they would like to use:

![upload](https://user-images.githubusercontent.com/18661283/44498921-22b55c80-a647-11e8-920b-4b6af4610912.png)

Works in both post-build actions and the pipeline.

To test the pipeline functionality, create a new Jenkins job of type "Pipeline". In the pipeline section add the script.

Here is a sample pipeline script:
```
node {
   stage('Build') {
        try {
            contrastVerification applicationName: 'NodeTestBench', count: 6, profile: 'new-profile', severity: 'High', appVersionTagFormat: 2
         }
         catch (err){
             throw err
        }
   }
}
```

There are 2 options for the appVersionTagFormat:
1 - default format: applicationName-buildNumber
2 - for hierarchical projects: applicationName-buildName-buildNumber