### PR TITLE
CONTRAST-26369

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -84,7 +84,12 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
-            String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), condition.getApplicationName());
+            String appName = condition.getApplicationName();
+            if (appName == null) {
+                appName = build.getParent().getDisplayName();
+            }
+
+            String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), appName);
             if (applicationId.equals("")) {
                 VulnerabilityTrendHelper.logMessage(listener, "Application with name '" + condition.getApplicationName() + "' not found.");
                 if (profile.isFailOnWrongApplicationName()) {


### PR DESCRIPTION
When the thresholdCondition.applicationName is null, job name is used as applicationName.