### PR TITLE
Contrast 27048

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/App.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/App.java
@@ -1,0 +1,12 @@
+package com.aspectsecurity.contrast.contrastjenkins;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class App {
+
+    public String name;
+    public String title;
+}

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
@@ -15,7 +15,6 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -29,7 +28,6 @@ import java.io.IOException;
  * Adds the necessary configuration options to a job's properties. Used in VulnerabilityTrendRecorder
  */
 public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
-    private String teamServerProfileName;
 
     @DataBoundConstructor
     public ContrastPluginConfig() {
@@ -45,26 +43,6 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
         } else {
             return null;
         }
-    }
-
-    public TeamServerProfile getProfile() {
-        return getProfile(teamServerProfileName);
-    }
-
-    public static TeamServerProfile getProfile(String profileName) {
-        final TeamServerProfile[] profiles = new ContrastPluginConfigDescriptor().getTeamServerProfiles();
-
-        if (profileName == null && ArrayUtils.isNotEmpty(profiles)) {
-            return profiles[0];
-        }
-
-        for (TeamServerProfile profile : profiles) {
-
-            if (StringUtils.equals(profileName, profile.getName())) {
-                return profile;
-            }
-        }
-        return null;
     }
 
     @Extension

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
@@ -4,7 +4,6 @@ import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.Extension;
-import hudson.RelativePath;
 import hudson.model.AbstractProject;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -94,12 +93,14 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
                 }
             }
 
-            // refresh all org rules
+            // refresh all org rules and applications
             for (TeamServerProfile teamServerProfile : teamServerProfiles) {
                 ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                         teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
                 teamServerProfile.setVulnerabilityTypes(VulnerabilityTrendHelper.saveRules(contrastSDK, teamServerProfile.getOrgUuid()));
+
+                teamServerProfile.setApps(VulnerabilityTrendHelper.saveApplicationIds(contrastSDK, teamServerProfile.getOrgUuid()));
             }
 
 
@@ -311,18 +312,6 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
         public FormValidation doCheckOrgUuid(@QueryParameter String value) {
             if (value.length() == 0)
                 return FormValidation.error("Please set an Organization Uuid.");
-            return FormValidation.ok();
-        }
-
-        /**
-         * Validation of the 'applicationName' form Field.
-         *
-         * @param value This parameter receives the value that the user has typed.
-         * @return Indicates the outcome of the validation. This is sent to the browser.
-         */
-        public FormValidation doCheckApplicationName(@QueryParameter String value) {
-            if (value.length() == 0)
-                return FormValidation.error("Please set an Application Name.");
             return FormValidation.ok();
         }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -22,8 +22,6 @@ public class TeamServerProfile {
 
     private String teamServerUrl;
 
-    private String applicationName;
-
     private List<VulnerabilityType> vulnerabilityTypes;
 
     private boolean failOnWrongApplicationId;
@@ -32,9 +30,11 @@ public class TeamServerProfile {
 
     private boolean allowGlobalThresholdConditionsOverride;
 
+    private List<App> apps;
+
     @DataBoundConstructor
     public TeamServerProfile(String name, String username, String apiKey, String serviceKey, String orgUuid,
-                             String teamServerUrl, String applicationName, boolean failOnWrongApplicationId,
+                             String teamServerUrl, boolean failOnWrongApplicationId,
                              String vulnerableBuildResult, boolean allowGlobalThresholdConditionsOverride) {
         this.name = name;
         this.username = username;
@@ -42,7 +42,6 @@ public class TeamServerProfile {
         this.serviceKey = serviceKey;
         this.orgUuid = orgUuid;
         this.teamServerUrl = teamServerUrl;
-        this.applicationName = applicationName;
         this.failOnWrongApplicationId = failOnWrongApplicationId;
         this.vulnerableBuildResult = vulnerableBuildResult;
         this.allowGlobalThresholdConditionsOverride = allowGlobalThresholdConditionsOverride;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -27,7 +27,7 @@ public class TeamServerProfile {
     private boolean failOnWrongApplicationId;
 
     /////// Compatibility fix for plugin versions <=2.6
-    private boolean failOnWrongApplicationName;
+    private Boolean failOnWrongApplicationName;
     ///////
 
     private String vulnerableBuildResult;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -26,7 +26,7 @@ public class TeamServerProfile {
 
     private List<VulnerabilityType> vulnerabilityTypes;
 
-    private boolean failOnWrongApplicationName;
+    private boolean failOnWrongApplicationId;
 
     private String vulnerableBuildResult;
 
@@ -34,7 +34,7 @@ public class TeamServerProfile {
 
     @DataBoundConstructor
     public TeamServerProfile(String name, String username, String apiKey, String serviceKey, String orgUuid,
-                             String teamServerUrl, String applicationName, boolean failOnWrongApplicationName,
+                             String teamServerUrl, String applicationName, boolean failOnWrongApplicationId,
                              String vulnerableBuildResult, boolean allowGlobalThresholdConditionsOverride) {
         this.name = name;
         this.username = username;
@@ -43,7 +43,7 @@ public class TeamServerProfile {
         this.orgUuid = orgUuid;
         this.teamServerUrl = teamServerUrl;
         this.applicationName = applicationName;
-        this.failOnWrongApplicationName = failOnWrongApplicationName;
+        this.failOnWrongApplicationId = failOnWrongApplicationId;
         this.vulnerableBuildResult = vulnerableBuildResult;
         this.allowGlobalThresholdConditionsOverride = allowGlobalThresholdConditionsOverride;
     }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -26,6 +26,10 @@ public class TeamServerProfile {
 
     private boolean failOnWrongApplicationId;
 
+    /////// Compatibility fix for plugin versions <=2.6
+    private boolean failOnWrongApplicationName;
+    ///////
+
     private String vulnerableBuildResult;
 
     private boolean allowGlobalThresholdConditionsOverride;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -27,7 +27,7 @@ public class TeamServerProfile {
     private boolean failOnWrongApplicationId;
 
     /////// Compatibility fix for plugin versions <=2.6
-    private Boolean failOnWrongApplicationName;
+    private boolean failOnWrongApplicationName;
     ///////
 
     private String vulnerableBuildResult;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/TeamServerProfile.java
@@ -28,7 +28,6 @@ public class TeamServerProfile {
 
     /////// Compatibility fix for plugin versions <=2.6
     private boolean failOnWrongApplicationName;
-    ///////
 
     private String vulnerableBuildResult;
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -31,6 +31,10 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
 
     private String applicationId;
 
+    //// Compatibility fix for plugin versions <=2.6
+    private String applicationName;
+    ////
+
     private boolean autoRemediated;
     private boolean confirmed;
     private boolean suspicious;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -41,7 +41,6 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
 
     //// Compatibility fix for plugin versions <=2.6
     private String applicationName;
-    ////
 
     @Setter
     private boolean autoRemediated;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -29,7 +29,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
 
     private String thresholdVulnType;
 
-    private String applicationName;
+    private String applicationId;
 
     private boolean autoRemediated;
     private boolean confirmed;
@@ -43,14 +43,14 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
 
     @DataBoundConstructor
     public ThresholdCondition(Integer thresholdCount, String thresholdSeverity, String thresholdVulnType,
-                              String applicationName, boolean autoRemediated, boolean confirmed, boolean suspicious,
+                              String applicationId, boolean autoRemediated, boolean confirmed, boolean suspicious,
                               boolean notAProblem, boolean remediated, boolean reported, boolean fixed,
                               boolean beingTracked, boolean untracked) {
 
         this.thresholdCount = thresholdCount;
         this.thresholdSeverity = thresholdSeverity;
         this.thresholdVulnType = thresholdVulnType;
-        this.applicationName = applicationName;
+        this.applicationId = applicationId;
 
         this.autoRemediated = autoRemediated;
         this.confirmed = confirmed;
@@ -77,8 +77,8 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
             sb.append(", rule type is ").append(thresholdVulnType);
         }
 
-        if (applicationName != null) {
-            sb.append(", application name is ").append(applicationName);
+        if (applicationId != null) {
+            sb.append(", application ID is ").append(applicationId);
         }
 
         sb.append(".");

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -138,22 +138,24 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
             return FormValidation.ok();
         }
 
-
         /**
-         * Validation of the 'applicationName' form Field.
+         * Validation of the 'applicationId' form Field.
          *
          * @param value This parameter receives the value that the user has typed.
          * @return Indicates the outcome of the validation. This is sent to the browser.
          */
-        public FormValidation doCheckApplicationName(@QueryParameter String value) {
-
-            if (value.isEmpty()) {
-                return FormValidation.error("Please enter an application name found in Teamserver.");
-            }
-
+        public FormValidation doCheckApplicationId(@QueryParameter String value) {
             return FormValidation.ok();
         }
 
+        /**
+         * Fills the Threshold Category select drop down with application ids.
+         *
+         * @return ListBoxModel filled with application ids.
+         */
+        public ListBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) throws IOException {
+            return VulnerabilityTrendHelper.getApplicationIds(teamServerProfileName);
+        }
 
         /**
          * Fills the Threshold Category select drop down with vulnerability types for the configured profile.

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -10,6 +10,7 @@ import hudson.util.ListBoxModel;
 import lombok.Getter;
 import lombok.Setter;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
@@ -20,29 +21,46 @@ import java.util.List;
  * ThresholdCondition class contains the variables and logic to populate the conditions when verifying for vulnerabilities.
  */
 @Getter
-@Setter
 public class ThresholdCondition extends AbstractDescribableImpl<ThresholdCondition> {
 
+    @Setter
     private Integer thresholdCount;
 
+    @Setter
     private String thresholdSeverity;
 
+    @Setter
     private String thresholdVulnType;
 
     private String applicationId;
+
+    @DataBoundSetter
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
 
     //// Compatibility fix for plugin versions <=2.6
     private String applicationName;
     ////
 
+    @Setter
     private boolean autoRemediated;
+    @Setter
     private boolean confirmed;
+    @Setter
     private boolean suspicious;
+    @Setter
     private boolean notAProblem;
+    @Setter
     private boolean remediated;
+    @Setter
     private boolean reported;
+
+    @Setter
     private boolean fixed;
+    @Setter
     private boolean beingTracked;
+    @Setter
     private boolean untracked;
 
     @DataBoundConstructor

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -68,43 +68,6 @@ public class VulnerabilityTrendHelper {
         return null;
     }
 
-    public static void updateConfiguration() {
-
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins == null) {
-            return;
-        }
-
-        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = jenkins.getDescriptorByType(ContrastPluginConfig.ContrastPluginConfigDescriptor.class);
-        VulnerabilityTrendRecorder.DescriptorImpl vulnerabilityTrendRecorderDescriptorImpl = jenkins.getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class);
-
-        final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
-
-        for (TeamServerProfile profile : profiles) {
-            if (profile.getApps() == null) {
-                ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
-                        profile.getApiKey(), profile.getTeamServerUrl());
-                List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
-                profile.setApps(apps);
-                profile.setFailOnWrongApplicationId(profile.isFailOnWrongApplicationName());
-
-                for (ThresholdCondition thresholdCondition : vulnerabilityTrendRecorderDescriptorImpl.getConditions()) {
-                    if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
-                        for (App app : profile.getApps()) {
-                            String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
-                            if (subStr.equals(thresholdCondition.getApplicationName())) {
-                                thresholdCondition.setApplicationId(app.getName());
-                                break;
-                            }
-                        }
-                    }
-                }
-                vulnerabilityTrendRecorderDescriptorImpl.save();
-                contrastPluginConfigDescriptor.save();
-            }
-        }
-    }
-
     public static List<GlobalThresholdCondition> getGlobalThresholdConditions(String profileName) {
         final GlobalThresholdCondition[] globalThresholdConditions = new ContrastPluginConfig.ContrastPluginConfigDescriptor().getGlobalThresholdConditions();
         List<GlobalThresholdCondition> globalThresholdConditionList = new ArrayList<>();
@@ -119,7 +82,6 @@ public class VulnerabilityTrendHelper {
             }
         }
         return globalThresholdConditionList;
-
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -107,7 +107,7 @@ public class VulnerabilityTrendHelper {
                 ThresholdCondition newThresholdCondition = new ThresholdCondition(
                         globalThresholdCondition.getThresholdCount(),
                         globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(),
-                        thresholdCondition.getApplicationName(),globalThresholdCondition.isAutoRemediated(),
+                        thresholdCondition.getApplicationId(),globalThresholdCondition.isAutoRemediated(),
                         globalThresholdCondition.isConfirmed(),globalThresholdCondition.isSuspicious(),
                         globalThresholdCondition.isNotAProblem(),globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
@@ -259,12 +259,12 @@ public class VulnerabilityTrendHelper {
     }
 
 
-    public static String buildAppVersionTag(Run<?, ?> build, String applicationName) {
-        return applicationName + "-" + build.getNumber();
+    public static String buildAppVersionTag(Run<?, ?> build, String applicationId) {
+        return applicationId + "-" + build.getNumber();
     }
 
-    public static String buildAppVersionTagHierarchical(Run<?, ?> build, String applicationName) {
-        return applicationName + "-" + build.getParent().getDisplayName() + "-" + build.getNumber();
+    public static String buildAppVersionTagHierarchical(Run<?, ?> build, String applicationId) {
+        return applicationId + "-" + build.getParent().getDisplayName() + "-" + build.getNumber();
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -70,8 +70,13 @@ public class VulnerabilityTrendHelper {
 
     public static void updateConfiguration() {
 
-        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = Jenkins.getInstance().getDescriptorByType(ContrastPluginConfig.ContrastPluginConfigDescriptor.class);
-        VulnerabilityTrendRecorder.DescriptorImpl vulnerabilityTrendRecorderDescriptorImpl = Jenkins.getInstance().getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return;
+        }
+
+        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = jenkins.getDescriptorByType(ContrastPluginConfig.ContrastPluginConfigDescriptor.class);
+        VulnerabilityTrendRecorder.DescriptorImpl vulnerabilityTrendRecorderDescriptorImpl = jenkins.getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class);
 
         final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -51,7 +51,8 @@ public class VulnerabilityTrendHelper {
         if (profileName == null)
             return null;
 
-        final TeamServerProfile[] profiles = new ContrastPluginConfig.ContrastPluginConfigDescriptor().getTeamServerProfiles();
+        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = new ContrastPluginConfig.ContrastPluginConfigDescriptor();
+        final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
 
         // Return the first profile; it is assumed that if it is empty,
         // it's the first element in a drop down that hasn't fully loaded yet
@@ -60,8 +61,21 @@ public class VulnerabilityTrendHelper {
         }
 
         for (TeamServerProfile profile : profiles) {
-            if (profileName.equals(profile.getName()))
+            if (profileName.equals(profile.getName())) {
+
+                /////// Compatibility fix for plugin versions <=2.6
+                if (profile.getApps() == null) {
+                    ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
+                            profile.getApiKey(), profile.getTeamServerUrl());
+                    List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
+                    profile.setApps(apps);
+                    contrastPluginConfigDescriptor.save();
+                }
+                ///////
+
                 return profile;
+            }
+
         }
         return null;
     }
@@ -109,6 +123,12 @@ public class VulnerabilityTrendHelper {
                         globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
                         globalThresholdCondition.isUntracked());
+
+                //// Compatibility fix for previous plugin version
+                if (thresholdCondition.getApplicationId() == null) {
+                    newThresholdCondition.setApplicationName(thresholdCondition.getApplicationName());
+                }
+                ////
 
                 newThresholdConditions.add(newThresholdCondition);
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -69,6 +69,7 @@ public class VulnerabilityTrendHelper {
                             profile.getApiKey(), profile.getTeamServerUrl());
                     List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
                     profile.setApps(apps);
+                    profile.setFailOnWrongApplicationId(profile.isFailOnWrongApplicationName());
                     contrastPluginConfigDescriptor.save();
                 }
                 ///////

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -3,10 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.RuleSeverity;
-import com.contrastsecurity.models.AgentType;
-import com.contrastsecurity.models.Rules;
-import com.contrastsecurity.models.Trace;
-import com.contrastsecurity.models.Traces;
+import com.contrastsecurity.models.*;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.ProxyConfiguration;
 import hudson.model.Run;
@@ -101,15 +98,15 @@ public class VulnerabilityTrendHelper {
         }
 
 
-        for (ThresholdCondition thresholdCondition: thresholdConditions) {
-            for (GlobalThresholdCondition globalThresholdCondition: globalThresholdConditions) {
+        for (ThresholdCondition thresholdCondition : thresholdConditions) {
+            for (GlobalThresholdCondition globalThresholdCondition : globalThresholdConditions) {
 
                 ThresholdCondition newThresholdCondition = new ThresholdCondition(
                         globalThresholdCondition.getThresholdCount(),
                         globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(),
-                        thresholdCondition.getApplicationId(),globalThresholdCondition.isAutoRemediated(),
-                        globalThresholdCondition.isConfirmed(),globalThresholdCondition.isSuspicious(),
-                        globalThresholdCondition.isNotAProblem(),globalThresholdCondition.isRemediated(),
+                        thresholdCondition.getApplicationId(), globalThresholdCondition.isAutoRemediated(),
+                        globalThresholdCondition.isConfirmed(), globalThresholdCondition.isSuspicious(),
+                        globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
                         globalThresholdCondition.isUntracked());
 
@@ -326,6 +323,72 @@ public class VulnerabilityTrendHelper {
             return info.toString();
         }
 
+    }
+
+    static boolean applicationIdExists(ContrastSDK sdk, String organizationUuid, String applicationId) {
+
+        if (applicationId == null || applicationId.isEmpty()) {
+            return false;
+        }
+
+        Applications applications;
+
+        try {
+            applications = sdk.getApplications(organizationUuid);
+        } catch (IOException | UnauthorizedException e) {
+            return false;
+        }
+
+        for (Application application : applications.getApplications()) {
+            if (applicationId.equals(application.getId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The apps for a profile
+     *
+     * @param teamServerProfileName Name of the profile
+     * @return ListBoxModel of apps
+     */
+    public static ListBoxModel getApplicationIds(String teamServerProfileName) {
+        ListBoxModel items = new ListBoxModel();
+
+        TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(teamServerProfileName);
+
+        if (teamServerProfile != null) {
+            for (App app : teamServerProfile.getApps()) {
+                items.add(app.getTitle(), app.getName());
+            }
+        }
+
+        return items;
+    }
+
+    /**
+     * Retrieves the applications
+     *
+     * @param sdk              Contrast SDK object
+     * @param organizationUuid uuid of the organization
+     */
+    public static List<App> saveApplicationIds(ContrastSDK sdk, String organizationUuid) {
+        Applications applications;
+        List<App> apps = new ArrayList<>();
+
+        try {
+            applications = sdk.getApplications(organizationUuid);
+        } catch (IOException | UnauthorizedException e) {
+            return apps;
+        }
+
+        for (Application application : applications.getApplications()) {
+            apps.add(new App(application.getId(), application.getId() + " (" + application.getName() + ")"));
+        }
+
+        return apps;
     }
 
     public static final String EMPTY_SELECT = "All";

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -69,11 +69,59 @@ public class VulnerabilityTrendHelper {
                             profile.getApiKey(), profile.getTeamServerUrl());
                     List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
                     profile.setApps(apps);
-                    profile.setFailOnWrongApplicationId(profile.isFailOnWrongApplicationName());
+                    profile.setFailOnWrongApplicationId(profile.getFailOnWrongApplicationName());
                     contrastPluginConfigDescriptor.save();
                 }
                 ///////
+                return profile;
+            }
 
+        }
+        return null;
+    }
+
+    public static TeamServerProfile getProfile(String profileName, VulnerabilityTrendRecorder vulnerabilityTrendRecorder) {
+        if (profileName == null)
+            return null;
+
+        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = new ContrastPluginConfig.ContrastPluginConfigDescriptor();
+        final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
+
+        // Return the first profile; it is assumed that if it is empty,
+        // it's the first element in a drop down that hasn't fully loaded yet
+        if (StringUtils.isEmpty(profileName)) {
+            return profiles[0];
+        }
+
+        for (TeamServerProfile profile : profiles) {
+            if (profileName.equals(profile.getName())) {
+
+                /////// Compatibility fix for plugin versions <=2.6
+                if (profile.getApps() == null) {
+                    ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
+                            profile.getApiKey(), profile.getTeamServerUrl());
+                    List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
+                    profile.setApps(apps);
+                    profile.setFailOnWrongApplicationId(profile.getFailOnWrongApplicationName());
+                    contrastPluginConfigDescriptor.save();
+                }
+                if (profile.getFailOnWrongApplicationName() != null) {
+                    for (ThresholdCondition thresholdCondition : vulnerabilityTrendRecorder.getConditions()) {
+                        if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
+                            for (App app : profile.getApps()) {
+                                String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
+                                if (subStr.equals(thresholdCondition.getApplicationName())) {
+                                    thresholdCondition.setApplicationId(app.getName());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    VulnerabilityTrendRecorder.DescriptorImpl descriptor = vulnerabilityTrendRecorder.getDescriptor();
+                    descriptor.setConditions(vulnerabilityTrendRecorder.getConditions());
+                    descriptor.save();
+                }
+                ///////
                 return profile;
             }
 
@@ -111,11 +159,8 @@ public class VulnerabilityTrendHelper {
         if (thresholdConditions == null || globalThresholdConditions == null) {
             return newThresholdConditions;
         }
-
-
         for (ThresholdCondition thresholdCondition : thresholdConditions) {
             for (GlobalThresholdCondition globalThresholdCondition : globalThresholdConditions) {
-
                 ThresholdCondition newThresholdCondition = new ThresholdCondition(
                         globalThresholdCondition.getThresholdCount(),
                         globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(),
@@ -124,19 +169,10 @@ public class VulnerabilityTrendHelper {
                         globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
                         globalThresholdCondition.isUntracked());
-
-                //// Compatibility fix for previous plugin version
-                if (thresholdCondition.getApplicationId() == null) {
-                    newThresholdCondition.setApplicationName(thresholdCondition.getApplicationName());
-                }
-                ////
-
                 newThresholdConditions.add(newThresholdCondition);
-
             }
         }
         return newThresholdConditions;
-
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -62,71 +62,42 @@ public class VulnerabilityTrendHelper {
 
         for (TeamServerProfile profile : profiles) {
             if (profileName.equals(profile.getName())) {
-
-                /////// Compatibility fix for plugin versions <=2.6
-                if (profile.getApps() == null) {
-                    ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
-                            profile.getApiKey(), profile.getTeamServerUrl());
-                    List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
-                    profile.setApps(apps);
-                    profile.setFailOnWrongApplicationId(profile.getFailOnWrongApplicationName());
-                    contrastPluginConfigDescriptor.save();
-                }
-                ///////
                 return profile;
             }
-
         }
         return null;
     }
 
-    public static TeamServerProfile getProfile(String profileName, VulnerabilityTrendRecorder vulnerabilityTrendRecorder) {
-        if (profileName == null)
-            return null;
+    public static void updateConfiguration() {
 
-        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = new ContrastPluginConfig.ContrastPluginConfigDescriptor();
+        ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = Jenkins.getInstance().getDescriptorByType(ContrastPluginConfig.ContrastPluginConfigDescriptor.class);
+        VulnerabilityTrendRecorder.DescriptorImpl vulnerabilityTrendRecorderDescriptorImpl = Jenkins.getInstance().getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class);
+
         final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
 
-        // Return the first profile; it is assumed that if it is empty,
-        // it's the first element in a drop down that hasn't fully loaded yet
-        if (StringUtils.isEmpty(profileName)) {
-            return profiles[0];
-        }
-
         for (TeamServerProfile profile : profiles) {
-            if (profileName.equals(profile.getName())) {
+            if (profile.getApps() == null) {
+                ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
+                        profile.getApiKey(), profile.getTeamServerUrl());
+                List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
+                profile.setApps(apps);
+                profile.setFailOnWrongApplicationId(profile.isFailOnWrongApplicationName());
 
-                /////// Compatibility fix for plugin versions <=2.6
-                if (profile.getApps() == null) {
-                    ContrastSDK contrastSDK = createSDK(profile.getUsername(), profile.getServiceKey(),
-                            profile.getApiKey(), profile.getTeamServerUrl());
-                    List<App> apps = saveApplicationIds(contrastSDK, profile.getOrgUuid());
-                    profile.setApps(apps);
-                    profile.setFailOnWrongApplicationId(profile.getFailOnWrongApplicationName());
-                    contrastPluginConfigDescriptor.save();
-                }
-                if (profile.getFailOnWrongApplicationName() != null) {
-                    for (ThresholdCondition thresholdCondition : vulnerabilityTrendRecorder.getConditions()) {
-                        if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
-                            for (App app : profile.getApps()) {
-                                String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
-                                if (subStr.equals(thresholdCondition.getApplicationName())) {
-                                    thresholdCondition.setApplicationId(app.getName());
-                                    break;
-                                }
+                for (ThresholdCondition thresholdCondition : vulnerabilityTrendRecorderDescriptorImpl.getConditions()) {
+                    if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
+                        for (App app : profile.getApps()) {
+                            String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
+                            if (subStr.equals(thresholdCondition.getApplicationName())) {
+                                thresholdCondition.setApplicationId(app.getName());
+                                break;
                             }
                         }
                     }
-                    VulnerabilityTrendRecorder.DescriptorImpl descriptor = vulnerabilityTrendRecorder.getDescriptor();
-                    descriptor.setConditions(vulnerabilityTrendRecorder.getConditions());
-                    descriptor.save();
                 }
-                ///////
-                return profile;
+                vulnerabilityTrendRecorderDescriptorImpl.save();
+                contrastPluginConfigDescriptor.save();
             }
-
         }
-        return null;
     }
 
     public static List<GlobalThresholdCondition> getGlobalThresholdConditions(String profileName) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -385,7 +385,7 @@ public class VulnerabilityTrendHelper {
         }
 
         for (Application application : applications.getApplications()) {
-            apps.add(new App(application.getId(), application.getId() + " (" + application.getName() + ")"));
+            apps.add(new App(application.getId(), application.getName() + " (" + application.getId() + ")"));
         }
 
         return apps;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -1,9 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
-import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
-import com.contrastsecurity.models.Application;
-import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -51,10 +48,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
         this.queryBy = queryBy;
     }
 
-    public TeamServerProfile getProfile() {
-        return VulnerabilityTrendHelper.getProfile(teamServerProfileName);
-    }
-
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) throws IOException {
 
@@ -67,12 +60,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
         Traces traces;
         Set<Trace> resultTraces = new HashSet<>();
 
-        TeamServerProfile profile = getProfile();
+        TeamServerProfile profile = VulnerabilityTrendHelper.getProfile(teamServerProfileName);
 
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
-
 
         List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
 
@@ -88,13 +80,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
-            String appId = condition.getApplicationId();
-            if (appId == null) {
-                appId = build.getParent().getDisplayName();
-            }
-
-            String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), appId);
-            if (applicationId.equals("")) {
+            boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), condition.getApplicationId());
+            if (!applicationIdExists) {
                 VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + condition.getApplicationId() + "' not found.");
                 if (profile.isFailOnWrongApplicationId()) {
                     throw new AbortException("Application with ID '" + condition.getApplicationId() + "' not found.");
@@ -127,9 +114,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if (!condition.getVulnerabilityStatuses().isEmpty()) {
                     filterForm.setStatus(condition.getVulnerabilityStatuses());
                 }
-
                 if (queryBy == Constants.QUERY_BY_START_DATE) {
-                    traces = contrastSDK.getTraces(profile.getOrgUuid(), applicationId, filterForm);
+                    traces = contrastSDK.getTraces(profile.getOrgUuid(), condition.getApplicationId(), filterForm);
                 } else {
                     traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
                 }
@@ -294,24 +280,4 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         build.addAction(new VulnerabilityFrequencyAction(result, build));
     }
-
-    private String getApplicationId(ContrastSDK sdk, String organizationUuid, String applicationId) {
-
-        Applications applications;
-
-        try {
-            applications = sdk.getApplications(organizationUuid);
-        } catch (IOException | UnauthorizedException e) {
-            return "";
-        }
-
-        for (Application application : applications.getApplications()) {
-            if (applicationId.equals(application.getId())) {
-                return application.getId();
-            }
-        }
-
-        return "";
-    }
-
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -7,7 +7,6 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
@@ -43,12 +42,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
 
     @DataBoundConstructor
-    public VulnerabilityTrendRecorder() {
-        DescriptorImpl descriptor = getDescriptor();
-        this.conditions = descriptor.conditions;
-        this.teamServerProfileName = descriptor.teamServerProfileName;
-        this.overrideGlobalThresholdConditions = descriptor.overrideGlobalThresholdConditions;
-        this.queryBy = descriptor.queryBy;
+    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName, boolean overrideGlobalThresholdConditions, int queryBy) {
+        this.conditions = conditions;
+        this.teamServerProfileName = teamServerProfileName;
+        this.overrideGlobalThresholdConditions = overrideGlobalThresholdConditions;
+        this.queryBy = queryBy;
     }
 
     protected Object readResolve() {
@@ -252,7 +250,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             save();
 
-            return new VulnerabilityTrendRecorder();
+            return new VulnerabilityTrendRecorder(conditions, teamServerProfileName, overrideGlobalThresholdConditions, queryBy);
         }
 
         public List<ThresholdCondition> getConditions() {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -70,7 +70,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             for (ThresholdCondition thresholdCondition : conditions) {
                 if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
-                    System.out.println("APP ID IS NULL");
                     TeamServerProfile profile = VulnerabilityTrendHelper.getProfile(teamServerProfileName);
                     for (App app : profile.getApps()) {
                         String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
@@ -80,7 +79,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         }
                     }
                 }
-                new VulnerabilityTrendRecorder(conditions, teamServerProfileName, overrideGlobalThresholdConditions, queryBy);
             }
         }
         return this;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -7,6 +7,8 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -41,11 +43,17 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
 
     @DataBoundConstructor
-    public VulnerabilityTrendRecorder(List<ThresholdCondition> conditions, String teamServerProfileName, boolean overrideGlobalThresholdConditions, int queryBy) {
-        this.conditions = conditions;
-        this.teamServerProfileName = teamServerProfileName;
-        this.overrideGlobalThresholdConditions = overrideGlobalThresholdConditions;
-        this.queryBy = queryBy;
+    public VulnerabilityTrendRecorder() {
+        DescriptorImpl descriptor = getDescriptor();
+        this.conditions = descriptor.conditions;
+        this.teamServerProfileName = descriptor.teamServerProfileName;
+        this.overrideGlobalThresholdConditions = descriptor.overrideGlobalThresholdConditions;
+        this.queryBy = descriptor.queryBy;
+    }
+
+    @Initializer
+    public static void init() {
+        VulnerabilityTrendHelper.updateConfiguration();
     }
 
     @Override
@@ -152,11 +160,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
         return true;
     }
 
-    @JavaScriptMethod
-    public void checkThresholdConditions() {
-        VulnerabilityTrendHelper.getProfile(teamServerProfileName, this);
-    }
-
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
@@ -180,6 +183,9 @@ public class VulnerabilityTrendRecorder extends Recorder {
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         private List<ThresholdCondition> conditions;
+        private String teamServerProfileName;
+        private Boolean overrideGlobalThresholdConditions;
+        private Integer queryBy;
 
         public DescriptorImpl() {
             super(VulnerabilityTrendRecorder.class);
@@ -235,10 +241,17 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     conditions.add(req.bindJSON(ThresholdCondition.class, json.getJSONObject("conditions")));
                 }
             }
+            teamServerProfileName = (String) json.get("teamServerProfileName");
+            overrideGlobalThresholdConditions = (Boolean) json.get("overrideGlobalThresholdConditions");
+            queryBy = Integer.parseInt((String) json.get("queryBy"));
 
             save();
 
-            return new VulnerabilityTrendRecorder(conditions, (String) json.get("teamServerProfileName"), (Boolean) json.get("overrideGlobalThresholdConditions"), Integer.parseInt((String) json.get("queryBy")));
+            return new VulnerabilityTrendRecorder();
+        }
+
+        public List<ThresholdCondition> getConditions() {
+            return conditions;
         }
 
         public void setConditions(List<ThresholdCondition> conditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -80,18 +80,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
-            //// Compatibility fix for plugin versions <=2.6
-            if (condition.getApplicationId() == null && condition.getApplicationName() != null) {
-                for (App app : profile.getApps()) {
-                    String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
-                    if (subStr.equals(condition.getApplicationName())) {
-                        condition.setApplicationId(app.getName());
-                        break;
-                    }
-                }
-            }
-            ////
-
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), condition.getApplicationId());
             if (!applicationIdExists) {
                 VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + condition.getApplicationId() + "' not found.");
@@ -162,6 +150,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
         VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
 
         return true;
+    }
+
+    @JavaScriptMethod
+    public void checkThresholdConditions() {
+        VulnerabilityTrendHelper.getProfile(teamServerProfileName, this);
     }
 
     @Override

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -88,16 +88,16 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
-            String appName = condition.getApplicationName();
-            if (appName == null) {
-                appName = build.getParent().getDisplayName();
+            String appId = condition.getApplicationId();
+            if (appId == null) {
+                appId = build.getParent().getDisplayName();
             }
 
-            String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), appName);
+            String applicationId = getApplicationId(contrastSDK, profile.getOrgUuid(), appId);
             if (applicationId.equals("")) {
-                VulnerabilityTrendHelper.logMessage(listener, "Application with name '" + condition.getApplicationName() + "' not found.");
-                if (profile.isFailOnWrongApplicationName()) {
-                    throw new AbortException("Application with name '" + condition.getApplicationName() + "' not found.");
+                VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + condition.getApplicationId() + "' not found.");
+                if (profile.isFailOnWrongApplicationId()) {
+                    throw new AbortException("Application with ID '" + condition.getApplicationId() + "' not found.");
                 }
             }
 
@@ -107,12 +107,12 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationId());
                     filterForm.setAppVersionTags(Collections.singletonList(appVersionTag));
                 } else if (queryBy == Constants.QUERY_BY_START_DATE) {
                     filterForm.setStartDate(build.getTime());
                 } else {
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationId());
                     filterForm.setAppVersionTags(Collections.singletonList(appVersionTag));
                 }
 
@@ -295,7 +295,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
         build.addAction(new VulnerabilityFrequencyAction(result, build));
     }
 
-    private String getApplicationId(ContrastSDK sdk, String organizationUuid, String applicationName) {
+    private String getApplicationId(ContrastSDK sdk, String organizationUuid, String applicationId) {
 
         Applications applications;
 
@@ -306,7 +306,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
         }
 
         for (Application application : applications.getApplications()) {
-            if (applicationName.equals(application.getName())) {
+            if (applicationId.equals(application.getId())) {
                 return application.getId();
             }
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -51,6 +51,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
         this.queryBy = descriptor.queryBy;
     }
 
+    protected Object readResolve() {
+        conditions = getDescriptor().conditions;
+        return this;
+    }
+
     @Initializer
     public static void init() {
         VulnerabilityTrendHelper.updateConfiguration();

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -80,6 +80,18 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
+            //// Compatibility fix for plugin versions <=2.6
+            if (condition.getApplicationId() == null && condition.getApplicationName() != null) {
+                for (App app : profile.getApps()) {
+                    String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
+                    if (subStr.equals(condition.getApplicationName())) {
+                        condition.setApplicationId(app.getName());
+                        break;
+                    }
+                }
+            }
+            ////
+
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), condition.getApplicationId());
             if (!applicationIdExists) {
                 VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + condition.getApplicationId() + "' not found.");

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -7,13 +7,13 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.init.Initializer;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import lombok.Getter;
 import lombok.Setter;
 import net.sf.json.JSONArray;
@@ -50,13 +50,40 @@ public class VulnerabilityTrendRecorder extends Recorder {
     }
 
     protected Object readResolve() {
-        conditions = getDescriptor().conditions;
-        return this;
-    }
 
-    @Initializer
-    public static void init() {
-        VulnerabilityTrendHelper.updateConfiguration();
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            ContrastPluginConfig.ContrastPluginConfigDescriptor contrastPluginConfigDescriptor = jenkins.getDescriptorByType(ContrastPluginConfig.ContrastPluginConfigDescriptor.class);
+
+            final TeamServerProfile[] profiles = contrastPluginConfigDescriptor.getTeamServerProfiles();
+            for (TeamServerProfile profile : profiles) {
+                if (profile.getApps() == null) {
+                    ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(),
+                            profile.getApiKey(), profile.getTeamServerUrl());
+                    List<App> apps = VulnerabilityTrendHelper.saveApplicationIds(contrastSDK, profile.getOrgUuid());
+                    profile.setApps(apps);
+                    profile.setFailOnWrongApplicationId(profile.isFailOnWrongApplicationName());
+
+                    contrastPluginConfigDescriptor.save();
+                }
+            }
+
+            for (ThresholdCondition thresholdCondition : conditions) {
+                if (thresholdCondition.getApplicationId() == null && thresholdCondition.getApplicationName() != null) {
+                    System.out.println("APP ID IS NULL");
+                    TeamServerProfile profile = VulnerabilityTrendHelper.getProfile(teamServerProfileName);
+                    for (App app : profile.getApps()) {
+                        String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
+                        if (subStr.equals(thresholdCondition.getApplicationName())) {
+                            thresholdCondition.setApplicationId(app.getName());
+                            break;
+                        }
+                    }
+                }
+                new VulnerabilityTrendRecorder(conditions, teamServerProfileName, overrideGlobalThresholdConditions, queryBy);
+            }
+        }
+        return this;
     }
 
     @Override

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -55,10 +55,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         this.severity = severity;
     }
 
-    private String applicationName;
+    private String applicationId;
 
     @DataBoundSetter
-    public void setApplicationName(String applicationName) { this.applicationName = applicationName; }
+    public void setApplicationId(String applicationId) { this.applicationId = applicationId; }
 
     private int queryBy;
 
@@ -68,12 +68,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     }
 
     @DataBoundConstructor
-    public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationName, int queryBy) {
+    public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationId, int queryBy) {
         this.profile = profile;
         this.count = count;
         this.rule = rule;
         this.severity = severity;
-        this.applicationName = applicationName;
+        this.applicationId = applicationId;
         this.queryBy = queryBy;
     }
 
@@ -146,10 +146,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 step.setSeverity((String) severity);
             }
 
-            if (arguments.containsKey("applicationName")) {
-                Object applicationName = arguments.get("applicationName");
+            if (arguments.containsKey("applicationId")) {
+                Object applicationId = arguments.get("applicationId");
 
-                step.setApplicationName((String) applicationName);
+                step.setApplicationId((String) applicationId);
             }
 
             if (arguments.containsKey("queryBy")) {
@@ -199,23 +199,23 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 throw new AbortException("Unable to find TeamServer profile.");
             }
 
-            if (step.getApplicationName() == null || step.getApplicationName().isEmpty()) {
-                step.setApplicationName(getBuildName());
-            }
+//            if (step.getApplicationId() == null || step.getApplicationId().isEmpty()) {
+//                step.setApplicationId(getBuildName());
+//            }
 
             if (step.getQueryBy() == 0) {
                 step.setQueryBy(Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
             }
 
-            VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationName());
+            VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
-            String applicationId = getApplicationId(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationName());
-            if (applicationId != null && applicationId.equals("")) {
-                VulnerabilityTrendHelper.logMessage(taskListener, "Application with name '" + step.getApplicationName() + "' not found.");
-                if (teamServerProfile.isFailOnWrongApplicationName()) {
-                    throw new AbortException("Application with name '" + step.getApplicationName() + "' not found.");
+            boolean applicationIdExists = applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
+            if (!applicationIdExists) {
+                VulnerabilityTrendHelper.logMessage(taskListener, "Application with ID '" + step.getApplicationId() + "' not found.");
+                if (teamServerProfile.isFailOnWrongApplicationId()) {
+                    throw new AbortException("Application with ID '" + step.getApplicationId() + "' not found.");
                 }
             }
 
@@ -228,14 +228,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             try {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
-                if (step.getApplicationName() != null) {
+                if (step.getApplicationId() != null) {
                     if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName())));
+                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId())));
                     } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                         filterForm.setStartDate(build.getTime());
                     }
                     else {
-                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName())));
+                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId())));
                     }
                 }
 
@@ -247,7 +247,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
                 }
                 if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                    traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), applicationId, filterForm);
+                    traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                 } else {
                     traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
                 }
@@ -292,8 +292,8 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             sb.append(", rule type is ").append(rule);
         }
 
-        if (applicationName != null) {
-            sb.append(", applicationName is ").append(applicationName);
+        if (applicationId != null) {
+            sb.append(", applicationId is ").append(applicationId);
         }
 
         if (queryBy != 0) {
@@ -305,22 +305,22 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         return sb.toString();
     }
 
-    private static String getApplicationId(ContrastSDK sdk, String organizationUuid, String applicationName) {
+    private static boolean applicationIdExists(ContrastSDK sdk, String organizationUuid, String applicationId) {
 
         Applications applications;
 
         try {
             applications = sdk.getApplications(organizationUuid);
         } catch (IOException | UnauthorizedException e) {
-            return "";
+            return false;
         }
 
         for (Application application : applications.getApplications()) {
-            if (applicationName.equals(application.getName())) {
-                return application.getId();
+            if (applicationId.equals(application.getId())) {
+                return true;
             }
         }
 
-        return "";
+        return false;
     }
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,9 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
-import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
-import com.contrastsecurity.models.Application;
-import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
@@ -58,7 +55,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     private String applicationId;
 
     @DataBoundSetter
-    public void setApplicationId(String applicationId) { this.applicationId = applicationId; }
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
 
     private int queryBy;
 
@@ -149,7 +148,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             if (arguments.containsKey("applicationId")) {
                 Object applicationId = arguments.get("applicationId");
 
-                step.setApplicationId((String) applicationId);
+                if (applicationId != null) {
+                    step.setApplicationId((String) applicationId);
+                } else {
+                    throw new IllegalArgumentException("Application ID must be set.");
+                }
+
             }
 
             if (arguments.containsKey("queryBy")) {
@@ -166,8 +170,17 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             return VulnerabilityTrendHelper.getProfileNames();
         }
 
+        /**
+         * Fills the Threshold Category select drop down with application ids.
+         *
+         * @return ListBoxModel filled with application ids.
+         */
+        public ListBoxModel doFillApplicationIdItems(@QueryParameter("profile") final String teamServerProfileName) throws IOException {
+            return VulnerabilityTrendHelper.getApplicationIds(teamServerProfileName);
+        }
+
         @SuppressWarnings("unused")
-        public ListBoxModel doFillRuleItems(@QueryParameter("teamServerProfileName") final String teamServerProfileName) {
+        public ListBoxModel doFillRuleItems(@QueryParameter("profile") final String teamServerProfileName) {
             return VulnerabilityTrendHelper.getVulnerabilityTypes(teamServerProfileName);
         }
 
@@ -199,19 +212,11 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 throw new AbortException("Unable to find TeamServer profile.");
             }
 
-//            if (step.getApplicationId() == null || step.getApplicationId().isEmpty()) {
-//                step.setApplicationId(getBuildName());
-//            }
-
-            if (step.getQueryBy() == 0) {
-                step.setQueryBy(Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
-            }
-
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
-            boolean applicationIdExists = applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
+            boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
             if (!applicationIdExists) {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Application with ID '" + step.getApplicationId() + "' not found.");
                 if (teamServerProfile.isFailOnWrongApplicationId()) {
@@ -228,15 +233,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             try {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
-                if (step.getApplicationId() != null) {
-                    if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId())));
-                    } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                        filterForm.setStartDate(build.getTime());
-                    }
-                    else {
-                        filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId())));
-                    }
+                if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+                    filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId())));
+                } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                    filterForm.setStartDate(build.getTime());
+                } else {
+                    filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId())));
                 }
 
                 if (step.getSeverity() != null) {
@@ -303,24 +305,5 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         sb.append(".");
 
         return sb.toString();
-    }
-
-    private static boolean applicationIdExists(ContrastSDK sdk, String organizationUuid, String applicationId) {
-
-        Applications applications;
-
-        try {
-            applications = sdk.getApplications(organizationUuid);
-        } catch (IOException | UnauthorizedException e) {
-            return false;
-        }
-
-        for (Application application : applications.getApplications()) {
-            if (applicationId.equals(application.getId())) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -59,6 +59,15 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         this.applicationId = applicationId;
     }
 
+    ////
+    private String applicationName;
+
+    @DataBoundSetter
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+    ////
+
     private int queryBy;
 
     @DataBoundSetter
@@ -156,6 +165,18 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             }
 
+            ////
+            if (arguments.containsKey("applicationName")) {
+                Object applicationName = arguments.get("applicationName");
+
+                if (applicationName != null) {
+                    step.setApplicationName((String) applicationName);
+                } else {
+                    throw new IllegalArgumentException("Application name must be set.");
+                }
+            }
+            ////
+
             if (arguments.containsKey("queryBy")) {
                 Object queryBy = arguments.get("queryBy");
 
@@ -211,6 +232,18 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Unable to find TeamServer profile.");
                 throw new AbortException("Unable to find TeamServer profile.");
             }
+
+            //// Compatibility fix for plugin versions <=2.6
+            if (step.getApplicationId() == null && step.getApplicationName() != null) {
+                for (App app : teamServerProfile.getApps()) {
+                    String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
+                    if (subStr.equals(step.getApplicationName())) {
+                        step.setApplicationId(app.getName());
+                        break;
+                    }
+                }
+            }
+            ////
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -59,14 +59,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         this.applicationId = applicationId;
     }
 
-    ////
     private String applicationName;
 
     @DataBoundSetter
     public void setApplicationName(String applicationName) {
         this.applicationName = applicationName;
     }
-    ////
 
     private int queryBy;
 
@@ -165,7 +163,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             }
 
-            ////
             if (arguments.containsKey("applicationName")) {
                 Object applicationName = arguments.get("applicationName");
 
@@ -175,7 +172,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     throw new IllegalArgumentException("Application name must be set.");
                 }
             }
-            ////
 
             if (arguments.containsKey("queryBy")) {
                 Object queryBy = arguments.get("queryBy");
@@ -243,7 +239,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     }
                 }
             }
-            ////
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig/global.jelly
@@ -30,8 +30,8 @@
                         <f:select field="vulnerableBuildResult" default="${profile.vulnerableBuildResult}"/>
                     </f:entry>
 
-                    <f:entry help="/plugin/contrast-continuous-application-security/help-failOnWrongApplicationName.html" >
-                        <f:checkbox title="Fail build if application is not found on TeamServer" name="failOnWrongApplicationName" field="failOnWrongApplicationName" value="${profile.failOnWrongApplicationName}" checked="${profile.failOnWrongApplicationName}" />
+                    <f:entry help="/plugin/contrast-continuous-application-security/help-failOnWrongApplicationId.html" >
+                        <f:checkbox title="Fail build if application is not found on TeamServer" name="failOnWrongApplicationId" field="failOnWrongApplicationId" value="${profile.failOnWrongApplicationId}" checked="${profile.failOnWrongApplicationId}" />
                     </f:entry>
 
                     <f:entry help="/plugin/contrast-continuous-application-security/help-allowGlobalThresholdConditionsOverride.html" >

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -8,10 +8,10 @@
 
         <f:entry title="Query vulnerabilities by" field="queryBy" >
             <f:entry>
-                <f:radio name="queryBy" title="appVersionTag, format: applicationName-buildNumber" value="1" checked="true" />
+                <f:radio name="queryBy" title="appVersionTag, format: applicationId-buildNumber" value="1" checked="true" />
             </f:entry>
             <f:entry>
-                <f:radio name="queryBy" title="appVersionTag, format: applicationName-buildName-buildNumber" value="2" checked="${instance.queryBy == 2}" />
+                <f:radio name="queryBy" title="appVersionTag, format: applicationId-buildName-buildNumber" value="2" checked="${instance.queryBy == 2}" />
             </f:entry>
             <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
                 <f:radio name="queryBy" title="startDate (Build timestamp)" value="3" checked="${instance.queryBy == 3}" />
@@ -26,9 +26,9 @@
         <f:entry description="Conditions for verifying your build">
             <f:repeatable field="conditions">
                 <table width="100%">
-                    <f:entry title="Application Name"
-                             help="/plugin/contrast-continuous-application-security/help-applicationName.html">
-                        <f:textbox name="applicationName" field="applicationName" default="${it.displayName}"/>
+                    <f:entry title="Application Id"
+                             help="/plugin/contrast-continuous-application-security/help-applicationId.html">
+                        <f:textbox name="applicationId" field="applicationId"/>
                     </f:entry>
 
                     <f:entry title="Count" field="thresholdCount"

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -173,6 +173,9 @@
                 }
             });
         }
+        var vulnerabilityTrendRecorder =
+        <st:bind value="${instance}"/>
+        vulnerabilityTrendRecorder.checkThresholdConditions();
 
     </script>
 

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -26,9 +26,8 @@
         <f:entry description="Conditions for verifying your build">
             <f:repeatable field="conditions">
                 <table width="100%">
-                    <f:entry title="Application Id"
-                             help="/plugin/contrast-continuous-application-security/help-applicationId.html">
-                        <f:textbox name="applicationId" field="applicationId"/>
+                    <f:entry title="Application Id" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
+                        <f:select/>
                     </f:entry>
 
                     <f:entry title="Count" field="thresholdCount"
@@ -90,7 +89,7 @@
         document.getElementsByName("overrideGlobalThresholdConditions");
         var teamServerProfileSelectElements = document.getElementsByName("_.teamServerProfileName");
 
-        <!-- All the fields of a Threshold Condition except the application name will be hidden if the global threshold conditions are used -->
+        <!-- All the fields of a Threshold Condition except the application id will be hidden if the global threshold conditions are used -->
         var thresholdCountElements = document.getElementsByName("thresholdCount");
         var thresholdSeverityElements = document.getElementsByName("_.thresholdSeverity");
         var thresholdVulnTypeElements = document.getElementsByName("_.thresholdVulnType");

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -173,10 +173,6 @@
                 }
             });
         }
-        var vulnerabilityTrendRecorder =
-        <st:bind value="${instance}"/>
-        vulnerabilityTrendRecorder.checkThresholdConditions();
-
     </script>
 
 </j:jelly>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
@@ -5,8 +5,8 @@
             <f:select/>
         </f:entry>
 
-        <f:entry title="Application Id" field="applicationId" help="/plugin/contrast-continuous-application-security/help-applicationId.html">
-            <f:textbox field="applicationId"/>
+        <f:entry title="Application Id" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
+            <f:select/>
         </f:entry>
 
         <f:entry title="Count" field="count" help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/config.jelly
@@ -5,8 +5,8 @@
             <f:select/>
         </f:entry>
 
-        <f:entry title="Application Name" field="applicationName" help="/plugin/contrast-continuous-application-security/help-applicationName.html">
-            <f:textbox field="applicationName"/>
+        <f:entry title="Application Id" field="applicationId" help="/plugin/contrast-continuous-application-security/help-applicationId.html">
+            <f:textbox field="applicationId"/>
         </f:entry>
 
         <f:entry title="Count" field="count" help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
@@ -3,6 +3,6 @@
 
     Usage Example: <br>
     <code>
-        contrastVerification profile: 'Localhost', applicationName: WebGoat, count: 10, rule: xss, severity: High, queryBy: 1
+        contrastVerification profile: 'Localhost', applicationId: cb3ea678-38c8-4487-ba94-692a117e7966, count: 10, rule: xss, severity: High, queryBy: 1
     </code>
 </div>

--- a/src/main/webapp/help-applicationId.html
+++ b/src/main/webapp/help-applicationId.html
@@ -1,0 +1,3 @@
+<div>
+    ID of the application on TeamServer.
+</div>

--- a/src/main/webapp/help-applicationName.html
+++ b/src/main/webapp/help-applicationName.html
@@ -1,3 +1,0 @@
-<div>
-    Name of the application on TeamServer.
-</div>

--- a/src/main/webapp/help-failOnWrongApplicationId.html
+++ b/src/main/webapp/help-failOnWrongApplicationId.html
@@ -1,0 +1,3 @@
+<div>
+    This option allows you to fail builds if the specified application ID is not found on TeamServer.
+</div>

--- a/src/main/webapp/help-failOnWrongApplicationName.html
+++ b/src/main/webapp/help-failOnWrongApplicationName.html
@@ -1,3 +1,0 @@
-<div>
-    This option allows you to fail builds if the specified application name is not found on TeamServer.
-</div>

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -58,8 +58,8 @@ public class VulnerabilityTrendHelperTest extends TestCase {
     public void testBuildAppVersionTagHierarchical() {
         String parentDisplayName = "project";
         int buildNumber = 1;
-        String applicationName = "NodeTestBench";
-        String appVersionTagActual = applicationName + "-" + parentDisplayName + "-" + buildNumber;
+        String applicationId = "NodeTestBench";
+        String appVersionTagActual = applicationId + "-" + parentDisplayName + "-" + buildNumber;
 
         Run<?, ?> build = mock(Run.class);
 
@@ -70,7 +70,7 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         when(parent.getDisplayName()).thenReturn(parentDisplayName);
         when(build.getNumber()).thenReturn(buildNumber);
 
-        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationName);
+        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationId);
         assertEquals(appVersionTag, appVersionTagActual);
     }
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -56,7 +56,7 @@ public class VulnerabilityTrendRecorderTest {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
         ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
-        when(thresholdCondition.getApplicationName()).thenReturn("test");
+        when(thresholdCondition.getApplicationId()).thenReturn("test");
         when(thresholdCondition.getThresholdCount()).thenReturn(0);
         when(thresholdCondition.getThresholdSeverity()).thenReturn("test");
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
@@ -101,7 +101,7 @@ public class VulnerabilityTrendRecorderTest {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
         ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
-        when(thresholdCondition.getApplicationName()).thenReturn("test");
+        when(thresholdCondition.getApplicationId()).thenReturn("test");
         when(thresholdCondition.getThresholdCount()).thenReturn(0);
         when(thresholdCondition.getThresholdSeverity()).thenReturn("test");
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
@@ -146,7 +146,7 @@ public class VulnerabilityTrendRecorderTest {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
         ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
-        when(thresholdCondition.getApplicationName()).thenReturn("test");
+        when(thresholdCondition.getApplicationId()).thenReturn("test");
         when(thresholdCondition.getThresholdCount()).thenReturn(0);
         when(thresholdCondition.getThresholdSeverity()).thenReturn(null);
         when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
@@ -193,7 +193,7 @@ public class VulnerabilityTrendRecorderTest {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
         ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
-        when(thresholdCondition.getApplicationName()).thenReturn("test");
+        when(thresholdCondition.getApplicationId()).thenReturn("test");
         when(thresholdCondition.getThresholdCount()).thenReturn(0);
         when(thresholdCondition.getThresholdSeverity()).thenReturn("test");
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");
@@ -244,7 +244,7 @@ public class VulnerabilityTrendRecorderTest {
 
         List<ThresholdCondition> conditions = new ArrayList<>();
         ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
-        when(thresholdCondition.getApplicationName()).thenReturn("test");
+        when(thresholdCondition.getApplicationId()).thenReturn("test");
         when(thresholdCondition.getThresholdCount()).thenReturn(0);
         when(thresholdCondition.getThresholdSeverity()).thenReturn("test");
         when(thresholdCondition.getThresholdVulnType()).thenReturn("test");

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -63,7 +63,7 @@ public class VulnerabilityTrendRecorderTest {
         conditions.add(thresholdCondition);
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -73,7 +73,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false,
+                "www.google.com", "org-uuid", false,
                 Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -108,7 +108,7 @@ public class VulnerabilityTrendRecorderTest {
         conditions.add(thresholdCondition);
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(10);
@@ -118,7 +118,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false,
+                "www.google.com", "org-uuid", false,
                 Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -163,7 +163,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false,
+                "www.google.com", "org-uuid", false,
                 Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -187,7 +187,6 @@ public class VulnerabilityTrendRecorderTest {
     }
 
 
-
     @Test
     public void testSuccessfulBuildStatusFilterEmpty() throws Exception {
 
@@ -200,7 +199,7 @@ public class VulnerabilityTrendRecorderTest {
         conditions.add(thresholdCondition);
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -210,7 +209,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins",
+                "www.google.com", "org-uuid",
                 false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -258,7 +257,7 @@ public class VulnerabilityTrendRecorderTest {
         conditions.add(thresholdCondition);
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
-                "test", true,Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
@@ -268,7 +267,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false,
+                "www.google.com", "org-uuid", false,
                 Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -311,7 +310,7 @@ public class VulnerabilityTrendRecorderTest {
         final String buildParentDisplayName = "Project";
         ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All",
                 appName, true, true, true, true, true,
-                true,true, true,true);
+                true, true, true, true);
         conditions.add(thresholdCondition);
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
@@ -327,7 +326,7 @@ public class VulnerabilityTrendRecorderTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false,
+                "www.google.com", "org-uuid", false,
                 Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -23,9 +23,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.*;
 
 
 @RunWith(PowerMockRunner.class)
@@ -74,7 +72,7 @@ public class VulnerabilityTrendStepTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
@@ -86,7 +84,7 @@ public class VulnerabilityTrendStepTest {
     @Test(expected = AbortException.class)
     public void testUnsuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
-        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat",Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
 
@@ -105,7 +103,7 @@ public class VulnerabilityTrendStepTest {
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
 
         TeamServerProfile profile = new TeamServerProfile("local", "contrast", "demo", "demo",
-                "www.google.com", "org-uuid", "Jenkins", false, Result.FAILURE.toString(), true);
+                "www.google.com", "org-uuid", false, Result.FAILURE.toString(), true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 


### PR DESCRIPTION
Now, plugin uses application id instead of name to query vulnerabilities.
Plugin is not compatible with its previous version, so the global configuration, pipelines, and post-build actions need to be updated.

![post-build action](https://user-images.githubusercontent.com/18661283/45934775-68c44f80-bf68-11e8-9207-b223e3318fd7.png)

![pipeline syntax](https://user-images.githubusercontent.com/18661283/45934776-711c8a80-bf68-11e8-9a0a-6fc49725cbd3.png)

![untitled](https://user-images.githubusercontent.com/18661283/45934778-7a0d5c00-bf68-11e8-885d-9f54f9c8100b.png)
