### PR TITLE
query for appVersionTags with appId and appName

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -40,6 +40,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
     }
 
     //// Compatibility fix for plugin versions <=2.6
+    @Setter
     private String applicationName;
 
     @Setter

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -107,6 +107,9 @@ public class VulnerabilityTrendHelper {
                         globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
                         globalThresholdCondition.isUntracked());
+                if (thresholdCondition.getApplicationName() != null) {
+                    newThresholdCondition.setApplicationName(thresholdCondition.getApplicationName());
+                }
                 newThresholdConditions.add(newThresholdCondition);
             }
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -131,12 +131,30 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
                 if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
                     String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationId());
-                    filterForm.setAppVersionTags(Collections.singletonList(appVersionTag));
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (condition.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
                 } else if (queryBy == Constants.QUERY_BY_START_DATE) {
                     filterForm.setStartDate(build.getTime());
                 } else {
                     String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationId());
-                    filterForm.setAppVersionTags(Collections.singletonList(appVersionTag));
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (condition.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
                 }
 
                 if (condition.getThresholdSeverity() != null) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -18,7 +18,9 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -262,11 +264,32 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 TraceFilterForm filterForm = new TraceFilterForm();
 
                 if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                    filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId())));
+
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId());
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (step.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
                 } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                     filterForm.setStartDate(build.getTime());
                 } else {
-                    filterForm.setAppVersionTags(Collections.singletonList(VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId())));
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (step.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
                 }
 
                 if (step.getSeverity() != null) {


### PR DESCRIPTION
Now, the plugin will query for appVersionTags created using application UUID and applicationName (for backwards compatibility)
For testing, an application can be run with -Dcontrast.override.appversion=appUUID-%BUILD_NUMBER%
and -Dcontrast.override.appversion=appName-%BUILD_NUMBER%