### PR TITLE
Contrast 27923

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
@@ -15,4 +15,5 @@ public final class Constants {
     public static final int QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT = 1;
     public static final int QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT = 2;
     public static final int QUERY_BY_START_DATE = 3;
+    public static final int QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT_BUILD_FULL_NAME = 4;
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -262,6 +262,10 @@ public class VulnerabilityTrendHelper {
         return applicationId + "-" + build.getParent().getDisplayName() + "-" + build.getNumber();
     }
 
+    public static String buildAppVersionTagHierarchicalFullName(Run<?, ?> build, String applicationId) {
+        return applicationId + "-" + build.getParent().getFullName() + "-" + build.getNumber();
+    }
+
     /**
      * Number of traces by severity
      *

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
@@ -187,7 +188,9 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 } else {
                     traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
                 }
-            } catch (Exception e) {
+            }
+
+            catch (UnauthorizedException e) {
                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
                 throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
             }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -141,7 +141,20 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     }
 
                     filterForm.setAppVersionTags(appVersionTagsList);
-                } else if (queryBy == Constants.QUERY_BY_START_DATE) {
+                } else if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT_BUILD_FULL_NAME) {
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchicalFullName(build, condition.getApplicationId());
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (condition.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
+                }
+                else if (queryBy == Constants.QUERY_BY_START_DATE) {
                     filterForm.setStartDate(build.getTime());
                 } else {
                     String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationId());
@@ -168,6 +181,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if (!condition.getVulnerabilityStatuses().isEmpty()) {
                     filterForm.setStatus(condition.getVulnerabilityStatuses());
                 }
+                VulnerabilityTrendHelper.logMessage(listener, "filter form: " + filterForm.toString());
                 if (queryBy == Constants.QUERY_BY_START_DATE) {
                     traces = contrastSDK.getTraces(profile.getOrgUuid(), condition.getApplicationId(), filterForm);
                 } else {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -179,6 +179,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 Object queryBy = arguments.get("queryBy");
 
                 step.setQueryBy((int) queryBy);
+            } else if (arguments.containsKey("appVersionTagFormat")) {
+                Object queryBy = arguments.get("appVersionTagFormat");
+
+                step.setQueryBy((int) queryBy);
             }
 
             return step;
@@ -276,7 +280,21 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     }
 
                     filterForm.setAppVersionTags(appVersionTagsList);
-                } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                } else if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT_BUILD_FULL_NAME) {
+                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchicalFullName(build, step.getApplicationId());
+
+                    List<String> appVersionTagsList = new ArrayList<>();
+                    appVersionTagsList.add(appVersionTag);
+
+                    if (step.getApplicationName() != null) {
+                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
+                        appVersionTagsList.add(appVersionTagAppName);
+                    }
+
+                    filterForm.setAppVersionTags(appVersionTagsList);
+                }
+
+                else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                     filterForm.setStartDate(build.getTime());
                 } else {
                     String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
@@ -299,6 +317,8 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 if (step.getRule() != null) {
                     filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
                 }
+
+                VulnerabilityTrendHelper.logMessage(taskListener, "filter form: " + filterForm.toString());
                 if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                     traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                 } else {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -324,7 +325,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 } else {
                     traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
                 }
-            } catch (Exception e) {
+            } catch (UnauthorizedException | IOException e) {
                 VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
                 throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
             }

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -13,6 +13,9 @@
             <f:entry>
                 <f:radio name="queryBy" title="appVersionTag, format: applicationId-buildName-buildNumber" value="2" checked="${instance.queryBy == 2}" />
             </f:entry>
+            <f:entry>
+                <f:radio name="queryBy" title="appVersionTag, format: applicationId-buildFullName-buildNumber" value="4" checked="${instance.queryBy == 4}" />
+            </f:entry>
             <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
                 <f:radio name="queryBy" title="startDate (Build timestamp)" value="3" checked="${instance.queryBy == 3}" />
             </f:entry>


### PR DESCRIPTION
Added 4th queryBy option:
![image](https://user-images.githubusercontent.com/18661283/48240389-38116b80-e398-11e8-8fab-e6f51cfb55d4.png)

If the job is located inside a folder, the resulting appVersionTag will be "applicationId-folderPath/buildName-buildNumber". If it is not in a folder: "applicationId-buildName-buildNumber"

Sample pipeline script:

`node {
   stage('Build') {
      contrastVerification applicationId: 'cb3ea678-38c8-4487-ba94-692a117e7966', profile: 'localhost', severity: 'High, queryBy: 4'
   }
}`