### PR TITLE
use build full name to create appVersionTag

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -249,17 +249,12 @@ public class VulnerabilityTrendHelper {
         }
     }
 
-    public static String buildAppVersionTag(Run<?, ?> build) {
-        return build.getParent().getDisplayName() + "-" + build.getNumber();
-    }
-
-
     public static String buildAppVersionTag(Run<?, ?> build, String applicationId) {
         return applicationId + "-" + build.getNumber();
     }
 
     public static String buildAppVersionTagHierarchical(Run<?, ?> build, String applicationId) {
-        return applicationId + "-" + build.getParent().getDisplayName() + "-" + build.getNumber();
+        return applicationId + "-" + build.getParent().getFullName() + "-" + build.getNumber();
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
@@ -168,12 +169,13 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if (!condition.getVulnerabilityStatuses().isEmpty()) {
                     filterForm.setStatus(condition.getVulnerabilityStatuses());
                 }
+                VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                 if (queryBy == Constants.QUERY_BY_START_DATE) {
                     traces = contrastSDK.getTraces(profile.getOrgUuid(), condition.getApplicationId(), filterForm);
                 } else {
                     traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
                 }
-            } catch (Exception e) {
+            } catch (UnauthorizedException e) {
                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
                 throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
             }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -179,6 +180,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 Object queryBy = arguments.get("queryBy");
 
                 step.setQueryBy((int) queryBy);
+            } else if (arguments.containsKey("appVersionTagFormat")) {
+                Object queryBy = arguments.get("appVersionTagFormat");
+                step.setQueryBy((int) queryBy);
             }
 
             return step;
@@ -299,12 +303,13 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 if (step.getRule() != null) {
                     filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
                 }
+                VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
                 if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                     traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                 } else {
                     traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
                 }
-            } catch (Exception e) {
+            } catch (UnauthorizedException | IOException e) {
                 VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
                 throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
             }
@@ -328,7 +333,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         }
 
         String getBuildName() {
-            return build.getParent().getDisplayName();
+            return build.getParent().getFullName();
         }
     }
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -2,10 +2,13 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
+import hudson.model.AbstractProject;
+import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import junit.framework.TestCase;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,20 +58,23 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         assertEquals("", info);
     }
 
+    @Test
     public void testBuildAppVersionTagHierarchical() {
-        String parentDisplayName = "project";
+        String parentFullName = "project";
         int buildNumber = 1;
         String applicationId = "NodeTestBench";
-        String appVersionTagActual = applicationId + "-" + parentDisplayName + "-" + buildNumber;
+        String appVersionTagActual = applicationId + "-" + parentFullName + "-" + buildNumber;
 
         Run<?, ?> build = mock(Run.class);
 
         Job parent = mock(Job.class);
+        ItemGroup itemGroup = mock(ItemGroup.class);
+        when(itemGroup.getFullName()).thenReturn("");
+        when(parent.getParent()).thenReturn(itemGroup);
 
-        when(build.getParent()).thenReturn(parent);
-
-        when(parent.getDisplayName()).thenReturn(parentDisplayName);
         when(build.getNumber()).thenReturn(buildNumber);
+        when(build.getParent()).thenReturn(parent);
+        when(parent.getFullName()).thenReturn(parentFullName);
 
         String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationId);
         assertEquals(appVersionTag, appVersionTagActual);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -311,7 +311,7 @@ public class VulnerabilityTrendRecorderTest {
         List<ThresholdCondition> conditions = new ArrayList<>();
         final String appName = "WebGoat";
         final int buildNumber = 1;
-        final String buildParentDisplayName = "Project";
+        final String buildParentFullName = "Project";
         ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All",
                 appName, true, true, true, true, true,
                 true, true, true, true);
@@ -345,7 +345,7 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
             public Traces answer(InvocationOnMock invocationOnMock) {
                 TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
-                Assert.assertEquals(traceFilterForm.getAppVersionTags().get(0), appName + "-" + buildParentDisplayName + "-" + buildNumber);
+                Assert.assertEquals(traceFilterForm.getAppVersionTags().get(0), appName + "-" + buildParentFullName + "-" + buildNumber);
                 return tracesMock;
             }
         });
@@ -354,7 +354,11 @@ public class VulnerabilityTrendRecorderTest {
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        when(parent.getDisplayName()).thenReturn(buildParentDisplayName);
+        ItemGroup itemGroup = mock(ItemGroup.class);
+        when(itemGroup.getFullName()).thenReturn("");
+        when(parent.getParent()).thenReturn(itemGroup);
+
+        when(parent.getFullName()).thenReturn(buildParentFullName);
 
         Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
 


### PR DESCRIPTION
If the job is located inside a folder, the resulting appVersionTag will be "applicationId-folderPath/buildName-buildNumber". If it is not in a folder: "applicationId-buildName-buildNumber"