### PR TITLE
do not check for vulnerabilities if application id is not found

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -128,79 +128,79 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if (profile.isFailOnWrongApplicationId()) {
                     throw new AbortException("Application with ID '" + appId + "' not found.");
                 }
-            }
+            } else {
+                VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
 
-            VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
+                try {
+                    TraceFilterForm filterForm = new TraceFilterForm();
 
-            try {
-                TraceFilterForm filterForm = new TraceFilterForm();
+                    if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, appId);
 
-                if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, appId);
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
 
-                    List<String> appVersionTagsList = new ArrayList<>();
-                    appVersionTagsList.add(appVersionTag);
+                        if (condition.getApplicationName() != null) {
+                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                            appVersionTagsList.add(appVersionTagAppName);
+                        }
 
-                    if (condition.getApplicationName() != null) {
-                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
-                        appVersionTagsList.add(appVersionTagAppName);
+                        filterForm.setAppVersionTags(appVersionTagsList);
+                    } else if (queryBy == Constants.QUERY_BY_START_DATE) {
+                        filterForm.setStartDate(build.getTime());
+                    } else {
+                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, appId);
+
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
+
+                        if (condition.getApplicationName() != null) {
+                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
+                            appVersionTagsList.add(appVersionTagAppName);
+                        }
+
+                        filterForm.setAppVersionTags(appVersionTagsList);
                     }
 
-                    filterForm.setAppVersionTags(appVersionTagsList);
-                } else if (queryBy == Constants.QUERY_BY_START_DATE) {
-                    filterForm.setStartDate(build.getTime());
-                } else {
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, appId);
-
-                    List<String> appVersionTagsList = new ArrayList<>();
-                    appVersionTagsList.add(appVersionTag);
-
-                    if (condition.getApplicationName() != null) {
-                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
-                        appVersionTagsList.add(appVersionTagAppName);
+                    if (condition.getThresholdSeverity() != null) {
+                        filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(condition.getThresholdSeverity()));
                     }
 
-                    filterForm.setAppVersionTags(appVersionTagsList);
+                    if (condition.getThresholdVulnType() != null) {
+                        filterForm.setVulnTypes(Collections.singletonList(condition.getThresholdVulnType()));
+                    }
+
+                    if (!condition.getVulnerabilityStatuses().isEmpty()) {
+                        filterForm.setStatus(condition.getVulnerabilityStatuses());
+                    }
+                    VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
+                    if (queryBy == Constants.QUERY_BY_START_DATE) {
+                        traces = contrastSDK.getTraces(profile.getOrgUuid(), appId, filterForm);
+                    } else {
+                        traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
+                    }
+                } catch (UnauthorizedException e) {
+                    VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+                    throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
                 }
 
-                if (condition.getThresholdSeverity() != null) {
-                    filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(condition.getThresholdSeverity()));
-                }
+                resultTraces.addAll(traces.getTraces());
 
-                if (condition.getThresholdVulnType() != null) {
-                    filterForm.setVulnTypes(Collections.singletonList(condition.getThresholdVulnType()));
-                }
+                int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
 
-                if (!condition.getVulnerabilityStatuses().isEmpty()) {
-                    filterForm.setStatus(condition.getVulnerabilityStatuses());
-                }
-                VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
-                if (queryBy == Constants.QUERY_BY_START_DATE) {
-                    traces = contrastSDK.getTraces(profile.getOrgUuid(), appId, filterForm);
-                } else {
-                    traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
-                }
-            } catch (UnauthorizedException e) {
-                VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
-            }
+                if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
+                    // save results before failing build
+                    buildResult(resultTraces, build);
 
-            resultTraces.addAll(traces.getTraces());
-
-            int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
-
-            if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
-                // save results before failing build
-                buildResult(resultTraces, build);
-
-                Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
-                VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
-                VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                    throw new AbortException("Failed on the threshold condition where " + condition.toString());
-                } else {
-                    build.setResult(buildResult);
-                    return true;
+                    Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
+                    VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
+                    VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                    if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                        throw new AbortException("Failed on the threshold condition where " + condition.toString());
+                    } else {
+                        build.setResult(buildResult);
+                        return true;
+                    }
                 }
             }
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -256,79 +256,78 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 if (teamServerProfile.isFailOnWrongApplicationId()) {
                     throw new AbortException("Application with ID '" + step.getApplicationId() + "' not found.");
                 }
-            }
+            } else {
+                Traces traces;
 
-            Traces traces;
+                String stepString = step.buildStepString();
 
-            String stepString = step.buildStepString();
+                VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
 
-            VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
+                try {
+                    TraceFilterForm filterForm = new TraceFilterForm();
 
-            try {
-                TraceFilterForm filterForm = new TraceFilterForm();
+                    if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
 
-                if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId());
 
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId());
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
 
-                    List<String> appVersionTagsList = new ArrayList<>();
-                    appVersionTagsList.add(appVersionTag);
+                        if (step.getApplicationName() != null) {
+                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
+                            appVersionTagsList.add(appVersionTagAppName);
+                        }
 
-                    if (step.getApplicationName() != null) {
-                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
-                        appVersionTagsList.add(appVersionTagAppName);
+                        filterForm.setAppVersionTags(appVersionTagsList);
+                    } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                        filterForm.setStartDate(build.getTime());
+                    } else {
+                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
+
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
+
+                        if (step.getApplicationName() != null) {
+                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName());
+                            appVersionTagsList.add(appVersionTagAppName);
+                        }
+
+                        filterForm.setAppVersionTags(appVersionTagsList);
                     }
 
-                    filterForm.setAppVersionTags(appVersionTagsList);
-                } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                    filterForm.setStartDate(build.getTime());
-                } else {
-                    String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
-
-                    List<String> appVersionTagsList = new ArrayList<>();
-                    appVersionTagsList.add(appVersionTag);
-
-                    if (step.getApplicationName() != null) {
-                        String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName());
-                        appVersionTagsList.add(appVersionTagAppName);
+                    if (step.getSeverity() != null) {
+                        filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(step.getSeverity()));
                     }
 
-                    filterForm.setAppVersionTags(appVersionTagsList);
+                    if (step.getRule() != null) {
+                        filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
+                    }
+                    VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
+                    if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                        traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
+                    } else {
+                        traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
+                    }
+                } catch (UnauthorizedException | IOException e) {
+                    VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
+                    throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
                 }
 
-                if (step.getSeverity() != null) {
-                    filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(step.getSeverity()));
+                if (traces.getCount() > step.getCount()) {
+                    Result buildResult = Result.fromString(teamServerProfile.getVulnerableBuildResult());
+                    VulnerabilityTrendHelper.logMessage(taskListener, "Failed on the condition where " + stepString);
+                    VulnerabilityTrendHelper.logMessage(taskListener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                    if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                        throw new AbortException("Failed on the condition where " + stepString);
+                    } else {
+                        build.setResult(buildResult);
+                        return null;
+                    }
+
                 }
 
-                if (step.getRule() != null) {
-                    filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
-                }
-                VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
-                if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                    traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
-                } else {
-                    traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
-                }
-            } catch (UnauthorizedException | IOException e) {
-                VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
+                VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
             }
-
-            if (traces.getCount() > step.getCount()) {
-                Result buildResult = Result.fromString(teamServerProfile.getVulnerableBuildResult());
-                VulnerabilityTrendHelper.logMessage(taskListener, "Failed on the condition where " + stepString);
-                VulnerabilityTrendHelper.logMessage(taskListener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                    throw new AbortException("Failed on the condition where " + stepString);
-                } else {
-                    build.setResult(buildResult);
-                    return null;
-                }
-
-            }
-
-            VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
-
             return null;
         }
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -116,11 +116,13 @@ public class VulnerabilityTrendRecorderTest {
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getName()).willReturn("local");
         given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
         given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -100,9 +100,11 @@ public class VulnerabilityTrendStepTest {
         doReturn("test").when(stepExecution).getBuildName();
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 


### PR DESCRIPTION
An additional 'else' block introduced some spacing, so spacing should be ignored when comparing files.