### PR TITLE
Adds option to set appversiontag via env variable

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/Constants.java
@@ -15,4 +15,5 @@ public final class Constants {
     public static final int QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT = 1;
     public static final int QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT = 2;
     public static final int QUERY_BY_START_DATE = 3;
+    public static final int QUERY_BY_PARAMETER = 4;
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -183,7 +183,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         filterForm.setStatus(condition.getVulnerabilityStatuses());
                     }
                     VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
-                    if (queryBy == Constants.QUERY_BY_START_DATE) {
+                    if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
                         traces = contrastSDK.getTraces(profile.getOrgUuid(), appId, filterForm);
                     } else {
                         traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -153,6 +153,10 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         final EnvVars env = build.getEnvironment(listener);
                         String appVersionTag = env.get("APPVERSIONTAG");
 
+                        if (appVersionTag.isEmpty()) {
+                            VulnerabilityTrendHelper.logMessage(listener, "Warning: queryBy Parameter is configured, but APPVERSIONTAG is not set. All vulnerabilities will be returned for this application.");
+                        }
+
                         List<String> appVersionTagsList = new ArrayList<>();
                         appVersionTagsList.add(appVersionTag);
                         

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.*;
@@ -86,7 +87,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
     }
 
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) throws IOException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
 
         if (!build.isBuilding()) {
             return false;
@@ -148,6 +149,14 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         filterForm.setAppVersionTags(appVersionTagsList);
                     } else if (queryBy == Constants.QUERY_BY_START_DATE) {
                         filterForm.setStartDate(build.getTime());
+                    } else if (queryBy == Constants.QUERY_BY_PARAMETER) {
+                        final EnvVars env = build.getEnvironment(listener);
+                        String appVersionTag = env.get("APPVERSIONTAG");
+
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
+                        
+                        filterForm.setAppVersionTags(appVersionTagsList);
                     } else {
                         String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, appId);
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.aspectsecurity.contrast.contrastjenkins.Constants;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Traces;
@@ -68,6 +69,13 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setApplicationName(String applicationName) {
         this.applicationName = applicationName;
+    }
+
+    private String appVersionTag;
+
+    @DataBoundSetter
+    public void setAppVersionTag(String appVersionTag) {
+        this.appVersionTag = appVersionTag;
     }
 
     private int queryBy;
@@ -181,6 +189,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 Object queryBy = arguments.get("queryBy");
 
                 step.setQueryBy((int) queryBy);
+
+                if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
+                    step.setAppVersionTag((String) arguments.get("appVersionTag"));
+                }
             } else if (arguments.containsKey("appVersionTagFormat")) {
                 Object queryBy = arguments.get("appVersionTagFormat");
                 step.setQueryBy((int) queryBy);
@@ -248,6 +260,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             }
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
+
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
@@ -284,7 +297,16 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         filterForm.setStartDate(build.getTime());
                     } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
                         final EnvVars env = build.getEnvironment(taskListener);
-                        String appVersionTag = env.get("APPVERSIONTAG");
+                        String appVersionTag = step.getAppVersionTag();
+
+                        // Always prefer value of appVersionTag in pipeline step over env var
+                        if (appVersionTag == null || appVersionTag.isEmpty()) {
+                            appVersionTag = env.get("APPVERSIONTAG");
+                        }
+
+                        if (appVersionTag.isEmpty()) {
+                            VulnerabilityTrendHelper.logMessage(taskListener, "Warning: queryBy Parameter is configured, but appVersionTag is not set. All vulnerabilities will be returned for this application.");
+                        }
 
                         List<String> appVersionTagsList = new ArrayList<>();
                         appVersionTagsList.add(appVersionTag);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -312,7 +312,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
                     }
                     VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
-                    if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                    if (step.getQueryBy() == Constants.QUERY_BY_START_DATE || step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
                         traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                     } else {
                         traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
 import hudson.AbortException;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -226,7 +227,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         transient VulnerabilityTrendStep step;
 
         @Override
-        public Void run() throws AbortException {
+        public Void run() throws AbortException, InterruptedException {
 
             TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(step.getProfile());
 
@@ -281,6 +282,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         filterForm.setAppVersionTags(appVersionTagsList);
                     } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
                         filterForm.setStartDate(build.getTime());
+                    } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
+                        final EnvVars env = build.getEnvironment(taskListener);
+                        String appVersionTag = env.get("APPVERSIONTAG");
+
+                        List<String> appVersionTagsList = new ArrayList<>();
+                        appVersionTagsList.add(appVersionTag);
+                        
+                        filterForm.setAppVersionTags(appVersionTagsList);
                     } else {
                         String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
 

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -16,6 +16,9 @@
             <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
                 <f:radio name="queryBy" title="startDate (Build timestamp)" value="3" checked="${instance.queryBy == 3}" />
             </f:entry>
+            <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
+                <f:radio name="queryBy" title="Parameter: APPVERSIONTAG" value="4" checked="${instance.queryBy == 4}" />
+            </f:entry>
         </f:entry>
 
         <f:entry>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -16,7 +16,7 @@
             <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
                 <f:radio name="queryBy" title="startDate (Build timestamp)" value="3" checked="${instance.queryBy == 3}" />
             </f:entry>
-            <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy.html">
+            <f:entry help="/plugin/contrast-continuous-application-security/help-queryBy-parameter.html">
                 <f:radio name="queryBy" title="Parameter: APPVERSIONTAG" value="4" checked="${instance.queryBy == 4}" />
             </f:entry>
         </f:entry>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep/help.html
@@ -13,6 +13,9 @@
     1 - appVersionTag, format: applicationId-${BUILD_NUMBER} (default) <br>
     2 - appVersionTag, format: applicationId-${JOB_NAME}-${BUILD_NUMBER} <br>
     3 - startDate (Build timestamp) <br>
+    4 - Job parameter (or environment variable): APPVERSIONTAG <br>
+    <br>
+    If you use the APPVERSIONTAG environment variable, the value can be any format of your choice.
     <br>
     Please note that the "queryBy" option should match the "contrast.override.appversion" parameter you pass to the Contrast Java agent when running your application.
     In case you use the third "queryBy" option, passing the "contrast.override.appversion" parameter to Contrast Java agent is not required.

--- a/src/main/webapp/help-queryBy-parameter.html
+++ b/src/main/webapp/help-queryBy-parameter.html
@@ -1,0 +1,4 @@
+<div>
+    Determine vulnerabilities in this build based on the value of the APPVERSIONTAG environment variable. This requires the application version reported by the Contrast agent match the value of APPVERSIONTAG.<br>
+    It may be necessary to override the value reported by the agent at runtime. For example, with the Java agent: -Dcontrast.override.appversion=v1.2.3 .
+</div>

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -80,6 +80,36 @@ public class VulnerabilityTrendStepTest {
         assertNull(stepExecution.run());
     }
 
+    @Test
+    public void testSuccessfulBuildWithParameter() throws Exception {
+        VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", Constants.QUERY_BY_PARAMETER);
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.taskListener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(0);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        doReturn("test").when(stepExecution).getBuildName();
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
+
+        assertNull(stepExecution.run());
+    }
+
     @Test(expected = AbortException.class)
     public void testUnsuccessfulBuild() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());


### PR DESCRIPTION
This introduces a queryBy option to filter vulnerabilities based on a custom string specified during build time as an environment variable.
![image](https://user-images.githubusercontent.com/3766558/59296968-c7dc0880-8c4c-11e9-8149-5187bbea1450.png)
Because parameters are exposed as environment variables, this also allows jobs to be easily parameterized.
![image](https://user-images.githubusercontent.com/3766558/59297234-5e102e80-8c4d-11e9-936f-3829ab151497.png)
