### PR TITLE
Adds support for paginated traces

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.RuleSeverity;
+import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.*;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.ProxyConfiguration;
@@ -19,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.*;
+
 
 public class VulnerabilityTrendHelper {
 
@@ -338,6 +340,80 @@ public class VulnerabilityTrendHelper {
             return info.toString();
         }
 
+    }
+    /**
+     * Collection of all traces for an application
+     *
+     * @param sdk ContrastSDK instance
+     * @param organizationId Organization ID of the application
+     * @param applicationId Application ID
+     * @param filter TraceFormFilter to limit results
+     * @return Traces object
+     */
+    public static Traces getAllApplicationTraces(ContrastSDK sdk, String organizationId, String applicationId, TraceFilterForm filter) throws IOException, UnauthorizedException {
+        Traces traces = new Traces();
+
+        // Contrast API returns traces paginated at 20 per page by default. Increase page size for faster transfer.
+        int page = 0;
+        int pageSize = 50;
+        filter.setLimit(pageSize);
+
+        do {
+            filter.setOffset(page * pageSize);
+
+            try {
+                Traces intermediateTraces = sdk.getTraces(organizationId, applicationId, filter);
+
+                if (page == 0) {
+                    traces = intermediateTraces;
+                } else {
+                    traces.getTraces().addAll(intermediateTraces.getTraces());
+                }
+            } catch (IOException | UnauthorizedException e) {
+                throw e;
+            }
+
+            page++;
+        } while (traces.getTraces().size() < traces.getCount());
+
+        return traces;
+    }
+
+    /**
+     * Collection of all traces in an organization
+     *
+     * @param sdk ContrastSDK instance
+     * @param organizationId Organization ID of the application
+     * @param filter TraceFormFilter to limit results
+     * @return Traces object
+     */
+    public static Traces getAllOrganizationTraces(ContrastSDK sdk, String organizationId, TraceFilterForm filter) throws IOException, UnauthorizedException {
+        Traces traces = new Traces();
+
+        // Contrast API returns traces paginated at 20 per page by default. Increase page size for faster transfer.
+        int page = 0;
+        int pageSize = 50;
+        filter.setLimit(pageSize);
+
+        do {
+            filter.setOffset(page * pageSize);
+
+            try {
+                Traces intermediateTraces = sdk.getTracesInOrg(organizationId, filter);
+
+                if (page == 0) {
+                    traces = intermediateTraces;
+                } else {
+                    traces.getTraces().addAll(intermediateTraces.getTraces());
+                }
+            } catch (IOException | UnauthorizedException e) {
+                throw e;
+            }
+
+            page++;
+        } while (traces.getTraces().size() < traces.getCount());
+
+        return traces;
     }
 
     static boolean applicationIdExists(ContrastSDK sdk, String organizationUuid, String applicationId) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -342,15 +342,15 @@ public class VulnerabilityTrendHelper {
 
     }
     /**
-     * Collection of all traces for an application
+     * Collection of all traces
      *
      * @param sdk ContrastSDK instance
      * @param organizationId Organization ID of the application
-     * @param applicationId Application ID
+     * @param applicationId Application ID (optional)
      * @param filter TraceFormFilter to limit results
      * @return Traces object
      */
-    public static Traces getAllApplicationTraces(ContrastSDK sdk, String organizationId, String applicationId, TraceFilterForm filter) throws IOException, UnauthorizedException {
+    public static Traces getAllTraces(ContrastSDK sdk, String organizationId, String applicationId, TraceFilterForm filter) throws IOException, UnauthorizedException {
         Traces traces = new Traces();
 
         // Contrast API returns traces paginated at 20 per page by default. Increase page size for faster transfer.
@@ -362,44 +362,14 @@ public class VulnerabilityTrendHelper {
             filter.setOffset(page * pageSize);
 
             try {
-                Traces intermediateTraces = sdk.getTraces(organizationId, applicationId, filter);
+                Traces intermediateTraces;
 
-                if (page == 0) {
-                    traces = intermediateTraces;
+                if (applicationId == null) {
+                    intermediateTraces = sdk.getTracesInOrg(organizationId, filter);
+
                 } else {
-                    traces.getTraces().addAll(intermediateTraces.getTraces());
+                    intermediateTraces = sdk.getTraces(organizationId, applicationId, filter);
                 }
-            } catch (IOException | UnauthorizedException e) {
-                throw e;
-            }
-
-            page++;
-        } while (traces.getTraces().size() < traces.getCount());
-
-        return traces;
-    }
-
-    /**
-     * Collection of all traces in an organization
-     *
-     * @param sdk ContrastSDK instance
-     * @param organizationId Organization ID of the application
-     * @param filter TraceFormFilter to limit results
-     * @return Traces object
-     */
-    public static Traces getAllOrganizationTraces(ContrastSDK sdk, String organizationId, TraceFilterForm filter) throws IOException, UnauthorizedException {
-        Traces traces = new Traces();
-
-        // Contrast API returns traces paginated at 20 per page by default. Increase page size for faster transfer.
-        int page = 0;
-        int pageSize = 50;
-        filter.setLimit(pageSize);
-
-        do {
-            filter.setOffset(page * pageSize);
-
-            try {
-                Traces intermediateTraces = sdk.getTracesInOrg(organizationId, filter);
 
                 if (page == 0) {
                     traces = intermediateTraces;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -188,9 +188,9 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     }
                     VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                     if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
-                        traces = contrastSDK.getTraces(profile.getOrgUuid(), appId, filterForm);
+                        traces = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
                     } else {
-                        traces = contrastSDK.getTracesInOrg(profile.getOrgUuid(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDK, profile.getOrgUuid(), filterForm);
                     }
                 } catch (UnauthorizedException e) {
                     VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
@@ -198,7 +198,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 }
 
                 resultTraces.addAll(traces.getTraces());
-
                 int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
 
                 if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -188,9 +188,9 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     }
                     VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                     if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
-                        traces = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
+                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
                     } else {
-                        traces = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDK, profile.getOrgUuid(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
                     }
                 } catch (UnauthorizedException e) {
                     VulnerabilityTrendHelper.logMessage(listener, e.getMessage());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -335,9 +335,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     }
                     VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
                     if (step.getQueryBy() == Constants.QUERY_BY_START_DATE || step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
-                        traces = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                     } else {
-                        traces = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDK, teamServerProfile.getOrgUuid(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), null, filterForm);
                     }
                 } catch (UnauthorizedException | IOException e) {
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -335,9 +335,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     }
                     VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
                     if (step.getQueryBy() == Constants.QUERY_BY_START_DATE || step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
-                        traces = contrastSDK.getTraces(teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
                     } else {
-                        traces = contrastSDK.getTracesInOrg(teamServerProfile.getOrgUuid(), filterForm);
+                        traces = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDK, teamServerProfile.getOrgUuid(), filterForm);
                     }
                 } catch (UnauthorizedException | IOException e) {
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -1,21 +1,34 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
+import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.model.AbstractProject;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import junit.framework.TestCase;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(VulnerabilityTrendHelper.class)
 public class VulnerabilityTrendHelperTest extends TestCase {
 
     @Test
@@ -78,5 +91,71 @@ public class VulnerabilityTrendHelperTest extends TestCase {
 
         String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationId);
         assertEquals(appVersionTag, appVersionTagActual);
+    }
+
+    @Test
+    public void testGetAllApplicationTraces() throws Exception {
+        Application application = mock(Application.class);
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
+        Traces page1 = mock(Traces.class);
+        Traces page2 = mock(Traces.class);
+
+        List<Trace> traceList1 = new ArrayList<>();
+        List<Trace> traceList2 = new ArrayList<>();
+
+        for (int i = 0; i < 50; i++) {
+            traceList1.add(mock(Trace.class));
+        }
+
+        traceList2.add(mock(Trace.class));
+
+        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
+
+        when(application.getId()).thenReturn("test");
+        when(page1.getCount()).thenReturn(51);
+        when(page2.getCount()).thenReturn(51);
+        when(page1.getTraces()).thenReturn(traceList1);
+        when(page2.getTraces()).thenReturn(traceList2);
+        when(contrastSDKMock.getTraces(anyString(), anyString(), any(TraceFilterForm.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        Traces tracesReturned = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDKMock, "1", application.getId(), mockTraceFilterForm);
+
+        assertEquals(51, tracesReturned.getTraces().size());
+        verify(contrastSDKMock, times(2)).getTraces(anyString(), anyString(), any(TraceFilterForm.class));
+    }
+
+    @Test
+    public void testGetAllOrganizationTraces() throws Exception {
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
+        Traces page1 = mock(Traces.class);
+        Traces page2 = mock(Traces.class);
+
+        List<Trace> traceList1 = new ArrayList<>();
+        List<Trace> traceList2 = new ArrayList<>();
+
+        for (int i = 0; i < 50; i++) {
+            traceList1.add(mock(Trace.class));
+        }
+
+        traceList2.add(mock(Trace.class));
+
+        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
+
+        when(page1.getCount()).thenReturn(51);
+        when(page2.getCount()).thenReturn(51);
+        when(page1.getTraces()).thenReturn(traceList1);
+        when(page2.getTraces()).thenReturn(traceList2);
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        Traces tracesReturned = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDKMock, "1", mockTraceFilterForm);
+
+        assertEquals(51, tracesReturned.getTraces().size());
+        verify(contrastSDKMock, times(2)).getTracesInOrg(anyString(), any(TraceFilterForm.class));
     }
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;;
+;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 @RunWith(PowerMockRunner.class)
@@ -94,7 +94,7 @@ public class VulnerabilityTrendHelperTest extends TestCase {
     }
 
     @Test
-    public void testGetAllApplicationTraces() throws Exception {
+    public void testGetAllTracesForApplication() throws Exception {
         Application application = mock(Application.class);
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
         TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
@@ -121,14 +121,15 @@ public class VulnerabilityTrendHelperTest extends TestCase {
                 .thenReturn(page1)
                 .thenReturn(page2);
 
-        Traces tracesReturned = VulnerabilityTrendHelper.getAllApplicationTraces(contrastSDKMock, "1", application.getId(), mockTraceFilterForm);
+        Traces tracesReturned = VulnerabilityTrendHelper.getAllTraces(contrastSDKMock, "1", application.getId(), mockTraceFilterForm);
 
         assertEquals(51, tracesReturned.getTraces().size());
         verify(contrastSDKMock, times(2)).getTraces(anyString(), anyString(), any(TraceFilterForm.class));
     }
 
     @Test
-    public void testGetAllOrganizationTraces() throws Exception {
+    public void testGetAllTracesNullApplication() throws Exception {
+        Application application = mock(Application.class);
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
         TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
         Traces page1 = mock(Traces.class);
@@ -145,6 +146,7 @@ public class VulnerabilityTrendHelperTest extends TestCase {
 
         PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
 
+        when(application.getId()).thenReturn("test");
         when(page1.getCount()).thenReturn(51);
         when(page2.getCount()).thenReturn(51);
         when(page1.getTraces()).thenReturn(traceList1);
@@ -153,9 +155,31 @@ public class VulnerabilityTrendHelperTest extends TestCase {
                 .thenReturn(page1)
                 .thenReturn(page2);
 
-        Traces tracesReturned = VulnerabilityTrendHelper.getAllOrganizationTraces(contrastSDKMock, "1", mockTraceFilterForm);
+        Traces tracesReturned = VulnerabilityTrendHelper.getAllTraces(contrastSDKMock, "1", null, mockTraceFilterForm);
 
         assertEquals(51, tracesReturned.getTraces().size());
         verify(contrastSDKMock, times(2)).getTracesInOrg(anyString(), any(TraceFilterForm.class));
+    }
+
+    @Test
+    public void testGetAllTracesWhenEmptyResponse() throws Exception {
+        Application application = mock(Application.class);
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
+        Traces page1 = mock(Traces.class);
+        List<Trace> traceList = new ArrayList<>();
+
+        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
+
+        when(application.getId()).thenReturn("test");
+        when(page1.getCount()).thenReturn(0);
+        when(page1.getTraces()).thenReturn(traceList);
+        when(contrastSDKMock.getTraces(anyString(), anyString(), any(TraceFilterForm.class)))
+                .thenReturn(page1);
+
+        Traces tracesReturned = VulnerabilityTrendHelper.getAllTraces(contrastSDKMock, "1", application.getId(), mockTraceFilterForm);
+
+        assertEquals(0, tracesReturned.getTraces().size());
+        verify(contrastSDKMock, times(1)).getTraces(anyString(), anyString(), any(TraceFilterForm.class));
     }
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -14,6 +14,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -27,8 +28,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
@@ -126,7 +126,7 @@ public class VulnerabilityTrendRecorderTest {
         given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllOrganizationTraces(any(ContrastSDK.class), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
+import com.contrastsecurity.models.TraceFilter;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
@@ -125,6 +126,7 @@ public class VulnerabilityTrendRecorderTest {
         given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllOrganizationTraces(any(ContrastSDK.class), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -10,6 +10,7 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -137,7 +138,7 @@ public class VulnerabilityTrendStepTest {
         given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllOrganizationTraces(any(ContrastSDK.class), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -137,6 +137,7 @@ public class VulnerabilityTrendStepTest {
         given(profile.isFailOnWrongApplicationId()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllOrganizationTraces(any(ContrastSDK.class), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 


### PR DESCRIPTION
This PR fixes a situation where the Contrast Jenkins plugin logs the count of vulnerabilities found, but when viewing vulnerabilities for the associated build in TeamServer, there are more vulnerabilities than were reported in Jenkins.

The incorrect vulnerability count is caused by the Jenkins plugin not supporting pagination. By default, TeamServer returns vulnerability data in pages with 20 vulnerabilities per page. The Jenkins plugin only uses the first page of vulnerability data and does not attempt to retrieve the remaining pages. Thus, the vulnerability counts are incorrect for any build where more than 20 vulnerabilities were found.