### PR TITLE
Avoid appVersionTag null assignment

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -151,7 +151,13 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         filterForm.setStartDate(build.getTime());
                     } else if (queryBy == Constants.QUERY_BY_PARAMETER) {
                         final EnvVars env = build.getEnvironment(listener);
-                        String appVersionTag = env.get("APPVERSIONTAG");
+                        String appVersionTag;
+
+                        if (env.get("APPVERSIONTAG") != null) {
+                            appVersionTag = env.get("APPVERSIONTAG");
+                        } else {
+                            appVersionTag = "";
+                        }
 
                         if (appVersionTag.isEmpty()) {
                             VulnerabilityTrendHelper.logMessage(listener, "Warning: queryBy Parameter is configured, but APPVERSIONTAG is not set. All vulnerabilities will be returned for this application.");

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -297,11 +297,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         filterForm.setStartDate(build.getTime());
                     } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
                         final EnvVars env = build.getEnvironment(taskListener);
-                        String appVersionTag = step.getAppVersionTag();
+                        String appVersionTag;
 
-                        // Always prefer value of appVersionTag in pipeline step over env var
-                        if (appVersionTag == null || appVersionTag.isEmpty()) {
+                        if (step.getAppVersionTag() != null) {
+                            appVersionTag = step.getAppVersionTag();
+                        } else if (env.get("APPVERSIONTAG") != null) {
                             appVersionTag = env.get("APPVERSIONTAG");
+                        } else {
+                            appVersionTag = "";
                         }
 
                         if (appVersionTag.isEmpty()) {


### PR DESCRIPTION
A NullPointerException may occur in pipeline build jobs if appVersionTag is not passed as a step parameter nor exported as an environment variable. This PR makes the assignment more explicit so that appVersionTag is always a string.