### PR TITLE
Contrast 38246 jenkins always name agent contrastjar

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
@@ -111,9 +111,10 @@ public class ContrastAgentStep extends AbstractStepImpl {
 
         @Override
         public Void run() throws AbortException {
+            String agentFileName = VulnerabilityFrequencyAction.getDefaultAgentFileNameFromString(step.getAgentType());
 
             TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(step.getProfile());
-            File agentFile = new File(step.getOutputDirectory() + "/" + "contrast.jar");
+            File agentFile = new File(step.getOutputDirectory() + "/" + agentFileName);
 
             if (teamServerProfile == null) {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Unable to find TeamServer profile.");
@@ -138,14 +139,14 @@ public class ContrastAgentStep extends AbstractStepImpl {
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Saving agent to file.");
             /* Regular Java io will not work on remote Jenkins slaves.
-            *  The contrast.jar will not persist on the slave with java.io.File, probably due to how the Jenkins agent technology works.
+            *  The agent file will not persist on the slave with java.io.File, probably due to how the Jenkins agent technology works.
             *  It is better to use the Hudson libraries. */
             try {
                 filePath.child(step.getOutputDirectory()).mkdirs();
                 OutputStream outputStream = null;
                 InputStream inputStream = null;
                 try {
-                    outputStream = filePath.child(step.getOutputDirectory() + "/" + "contrast.jar").write();
+                    outputStream = filePath.child(step.getOutputDirectory() + "/" + agentFileName).write();
                     inputStream = new ByteArrayInputStream(agent);
                     IOUtils.copy(inputStream,outputStream);
                 } finally {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
@@ -111,7 +111,7 @@ public class ContrastAgentStep extends AbstractStepImpl {
 
         @Override
         public Void run() throws AbortException {
-            String agentFileName = VulnerabilityFrequencyAction.getDefaultAgentFileNameFromString(step.getAgentType());
+            String agentFileName = VulnerabilityTrendHelper.getDefaultAgentFileNameFromString(step.getAgentType());
 
             TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(step.getProfile());
             File agentFile = new File(step.getOutputDirectory() + "/" + agentFileName);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -273,6 +273,18 @@ public class VulnerabilityTrendHelper {
         }
     }
 
+    public static String getDefaultAgentFileNameFromString(String type) {
+        switch (type) {
+            case ".NET":
+                return "dotnet-contrast.zip";
+            case "Node":
+                return "node-contrast.tgz";
+            case "Java":
+            default:
+                return "contrast.jar";
+        }
+    }
+
     public static String buildAppVersionTag(Run<?, ?> build, String applicationId) {
         return applicationId + "-" + build.getNumber();
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -182,4 +182,22 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         assertEquals(0, tracesReturned.getTraces().size());
         verify(contrastSDKMock, times(1)).getTraces(anyString(), anyString(), any(TraceFilterForm.class));
     }
+
+    @Test
+    public void testGetDefaultAgentFileNameFromStringJava() throws Exception {
+        assertEquals("contrast.jar", VulnerabilityTrendHelper.getDefaultAgentFileNameFromString("Java"));
+    }
+    @Test
+    public void testGetDefaultAgtestGetDefaultAgentFileNameFromStringNode() throws Exception {
+        assertEquals("node-contrast.tgz", VulnerabilityTrendHelper.getDefaultAgentFileNameFromString("Node"));
+    }
+    @Test
+    public void testGetDefaultAgtestGetDefaultAgentFileNameFromStringDotNet() throws Exception {
+        assertEquals("dotnet-contrast.zip", VulnerabilityTrendHelper.getDefaultAgentFileNameFromString(".NET"));
+    }
+    @Test
+    public void testGetDefaultAgtestGetDefaultAgentFileNameFromStringEmpty() throws Exception {
+        assertEquals("contrast.jar", VulnerabilityTrendHelper.getDefaultAgentFileNameFromString(""));
+    }
+
 }


### PR DESCRIPTION
CONTRAST-38246 (Jenkins is always naming agents contrast.jar)
* added method to helper class to provide the proper name of the file based on the type provided.