### PR TITLE
Contrast 38919 add creating application support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
       <groupId>com.contrastsecurity</groupId>
       <artifactId>contrast-sdk-java</artifactId>
     <!--  <version>2.9</version> TODO: CHANGE ME -->
-      <version>2.11-SNAPSHOT</version>
+      <version>2.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
     <dependency>
       <groupId>com.contrastsecurity</groupId>
       <artifactId>contrast-sdk-java</artifactId>
-      <version>2.9</version>
+    <!--  <version>2.9</version> TODO: CHANGE ME -->
+      <version>2.11-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,7 @@
     <dependency>
       <groupId>com.contrastsecurity</groupId>
       <artifactId>contrast-sdk-java</artifactId>
-    <!--  <version>2.9</version> TODO: CHANGE ME -->
-      <version>2.12-SNAPSHOT</version>
+      <version>2.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
@@ -8,27 +8,25 @@ import org.kohsuke.stapler.DataBoundConstructor;
 @Getter
 @Setter
 public class ApplicationDefinition {
-    /**
-     * 0 = match using application id
-     * 1 = match using application orgin name and agent type
-     * 2 = match using application short name
-     */
-    private int value;
+
+    private MatchBy matchBy;
     private String applicationId;
     private String applicationOriginName;
     private String agentType;
-    private boolean isInstrumented;
     private boolean failOnAppNotFound;
     private String applicationShortName;
 
     @DataBoundConstructor
-    public ApplicationDefinition(int value, String applicationId, String applicationOriginName, String applicationShortName, String agentType, boolean doNotFailIfAppNotFound) {
-        this.value = value;
+    public ApplicationDefinition(String applicationId, String applicationOriginName, String applicationShortName, String agentType, boolean failOnAppNotFound) {
         this.applicationId = applicationId;
-        this.isInstrumented = (value == 0);
         this.applicationOriginName = applicationOriginName;
         this.applicationShortName = applicationShortName;
         this.agentType = agentType;
-        this.failOnAppNotFound = doNotFailIfAppNotFound;
+        this.failOnAppNotFound = failOnAppNotFound;
+        if(applicationOriginName != null) {
+            this.matchBy = MatchBy.APPLICATION_ORIGIN_NAME;
+        } else if(applicationShortName != null) {
+            this.matchBy = MatchBy.APPLICATION_SHORT_NAME;
+        }
     }
 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
@@ -1,0 +1,34 @@
+package com.aspectsecurity.contrast.contrastjenkins;
+
+import hudson.util.ListBoxModel;
+import lombok.Getter;
+import lombok.Setter;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+@Getter
+@Setter
+public class ApplicationDefinition {
+    /**
+     * 0 = match using application id
+     * 1 = match using application orgin name and agent type
+     * 2 = match using application short name
+     */
+    private int value;
+    private String applicationId;
+    private String applicationOriginName;
+    private String agentType;
+    private boolean isInstrumented;
+    private boolean failOnAppNotFound;
+    private String applicationShortName;
+
+    @DataBoundConstructor
+    public ApplicationDefinition(int value, String applicationId, String applicationOriginName, String applicationShortName, String agentType, boolean doNotFailIfAppNotFound) {
+        this.value = value;
+        this.applicationId = applicationId;
+        this.isInstrumented = (value == 0);
+        this.applicationOriginName = applicationOriginName;
+        this.applicationShortName = applicationShortName;
+        this.agentType = agentType;
+        this.failOnAppNotFound = doNotFailIfAppNotFound;
+    }
+}

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ApplicationDefinition.java
@@ -12,9 +12,9 @@ public class ApplicationDefinition {
     private MatchBy matchBy;
     private String applicationId;
     private String applicationOriginName;
-    private String agentType;
+    private String agentType; //Application Language in UI
     private boolean failOnAppNotFound;
-    private String applicationShortName;
+    private String applicationShortName; //Application Code in UI
 
     @DataBoundConstructor
     public ApplicationDefinition(String applicationId, String applicationOriginName, String applicationShortName, String agentType, boolean failOnAppNotFound) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/MatchBy.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/MatchBy.java
@@ -1,0 +1,7 @@
+package com.aspectsecurity.contrast.contrastjenkins;
+
+public enum MatchBy {
+    APPLICATION_ORIGIN_NAME,
+    APPLICATION_ID,
+    APPLICATION_SHORT_NAME
+}

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -24,21 +24,25 @@ import java.util.List;
 /**
  * ThresholdCondition class contains the variables and logic to populate the conditions when verifying for vulnerabilities.
  */
-@Getter
 public class ThresholdCondition extends AbstractDescribableImpl<ThresholdCondition> {
 
     @Setter
+    @Getter
     private Integer thresholdCount;
 
     @Setter
+    @Getter
     private String thresholdSeverity;
 
     @Setter
+    @Getter
     private String thresholdVulnType;
 
     @Setter
+    @Getter
     private ApplicationDefinition applicationDefinition;
 
+    @Getter
     private String applicationId;
 
     @DataBoundSetter
@@ -48,48 +52,73 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
 
     //// Compatibility fix for plugin versions <=2.6
     @Setter
+    @Getter
     private String applicationName;
 
     /**
      * Name that was used to instrument the agent
      */
     @Setter
+    @Getter
     private String applicationOriginName;
 
     /**
      * Type of agent used to instrument the application
      */
     @Setter
+    @Getter
     private String agentType;
 
     /**
      * Only gets set when application is not initiated
      */
     @Setter
+    @Getter
     private boolean failOnAppNotFound;
 
+    /**
+     * 0 = instrumented
+     * 1 = not instrumented
+     */
     @Setter
+    @Getter
+    private int applicationState;
+
+    @Setter
+    @Getter
+    private MatchBy matchBy;
+
+    @Setter
+    @Getter
     private boolean autoRemediated;
     @Setter
+    @Getter
     private boolean confirmed;
     @Setter
+    @Getter
     private boolean suspicious;
     @Setter
+    @Getter
     private boolean notAProblem;
     @Setter
+    @Getter
     private boolean remediated;
     @Setter
+    @Getter
     private boolean reported;
 
     @Setter
+    @Getter
     private boolean fixed;
     @Setter
+    @Getter
     private boolean beingTracked;
     @Setter
+    @Getter
     private boolean untracked;
 
     @DataBoundConstructor
-    public ThresholdCondition(Integer thresholdCount, String thresholdSeverity, String thresholdVulnType, ApplicationDefinition applicationDefinition,
+    public ThresholdCondition(Integer thresholdCount, String thresholdSeverity, String thresholdVulnType, int applicationState, ApplicationDefinition applicationDefinition,
                               String applicationId, boolean autoRemediated, boolean confirmed, boolean suspicious,
                               boolean notAProblem, boolean remediated, boolean reported, boolean fixed,
                               boolean beingTracked, boolean untracked) {
@@ -98,13 +127,15 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
         this.thresholdSeverity = thresholdSeverity;
         this.thresholdVulnType = thresholdVulnType;
         this.applicationDefinition = applicationDefinition;
-        if(applicationDefinition != null) {
-            this.applicationId = applicationDefinition.getApplicationId();
+        this.applicationId = applicationId;
+        this.applicationState = applicationState;
+        if(applicationState == 0) {
+            this.matchBy = MatchBy.APPLICATION_ID;
+        }else if(applicationDefinition != null) {
+            this.matchBy = applicationDefinition.getMatchBy();
             this.applicationOriginName = applicationDefinition.getApplicationOriginName();
             this.agentType = applicationDefinition.getAgentType();
             this.failOnAppNotFound = applicationDefinition.isFailOnAppNotFound();
-        } else {
-            this.applicationId = applicationId;
         }
 
         this.autoRemediated = autoRemediated;
@@ -214,7 +245,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
          *
          * @return ComboBoxModel filled with application ids.
          */
-        public ComboBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("../..") final String teamServerProfileName) {
+        public ComboBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) {
 
             // Refresh apps every ${appsRefreshIntervalMinutes} minutes before filling in the combobox
             if (lastAppsRefresh == null || (Calendar.getInstance().getTimeInMillis() - lastAppsRefresh.getTimeInMillis()) / 60000 >= appsRefreshIntervalMinutes) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -36,6 +36,9 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
     @Setter
     private String thresholdVulnType;
 
+    @Setter
+    private ApplicationDefinition applicationDefinition;
+
     private String applicationId;
 
     @DataBoundSetter
@@ -46,6 +49,24 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
     //// Compatibility fix for plugin versions <=2.6
     @Setter
     private String applicationName;
+
+    /**
+     * Name that was used to instrument the agent
+     */
+    @Setter
+    private String applicationOriginName;
+
+    /**
+     * Type of agent used to instrument the application
+     */
+    @Setter
+    private String agentType;
+
+    /**
+     * Only gets set when application is not initiated
+     */
+    @Setter
+    private boolean failOnAppNotFound;
 
     @Setter
     private boolean autoRemediated;
@@ -68,7 +89,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
     private boolean untracked;
 
     @DataBoundConstructor
-    public ThresholdCondition(Integer thresholdCount, String thresholdSeverity, String thresholdVulnType,
+    public ThresholdCondition(Integer thresholdCount, String thresholdSeverity, String thresholdVulnType, ApplicationDefinition applicationDefinition,
                               String applicationId, boolean autoRemediated, boolean confirmed, boolean suspicious,
                               boolean notAProblem, boolean remediated, boolean reported, boolean fixed,
                               boolean beingTracked, boolean untracked) {
@@ -76,7 +97,15 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
         this.thresholdCount = thresholdCount;
         this.thresholdSeverity = thresholdSeverity;
         this.thresholdVulnType = thresholdVulnType;
-        this.applicationId = applicationId;
+        this.applicationDefinition = applicationDefinition;
+        if(applicationDefinition != null) {
+            this.applicationId = applicationDefinition.getApplicationId();
+            this.applicationOriginName = applicationDefinition.getApplicationOriginName();
+            this.agentType = applicationDefinition.getAgentType();
+            this.failOnAppNotFound = applicationDefinition.isFailOnAppNotFound();
+        } else {
+            this.applicationId = applicationId;
+        }
 
         this.autoRemediated = autoRemediated;
         this.confirmed = confirmed;
@@ -185,7 +214,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
          *
          * @return ComboBoxModel filled with application ids.
          */
-        public ComboBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) {
+        public ComboBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("../..") final String teamServerProfileName) {
 
             // Refresh apps every ${appsRefreshIntervalMinutes} minutes before filling in the combobox
             if (lastAppsRefresh == null || (Calendar.getInstance().getTimeInMillis() - lastAppsRefresh.getTimeInMillis()) / 60000 >= appsRefreshIntervalMinutes) {
@@ -208,6 +237,10 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
                 teamServerProfile.setApps(VulnerabilityTrendHelper.saveApplicationIds(contrastSDK, teamServerProfile.getOrgUuid()));
                 contrastPluginConfigDescriptor.save();
             }
+        }
+
+        public ListBoxModel doFillAgentTypeItems() {
+            return VulnerabilityTrendHelper.getAgentTypeListBoxModel();
         }
 
         /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -125,7 +125,7 @@ public class VulnerabilityTrendHelper {
             for (GlobalThresholdCondition globalThresholdCondition : globalThresholdConditions) {
                 ThresholdCondition newThresholdCondition = new ThresholdCondition(
                         globalThresholdCondition.getThresholdCount(),
-                        globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(), thresholdCondition.getApplicationDefinition(),
+                        globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(), thresholdCondition.getApplicationState(), thresholdCondition.getApplicationDefinition(),
                         thresholdCondition.getApplicationId(),globalThresholdCondition.isAutoRemediated(),
                         globalThresholdCondition.isConfirmed(), globalThresholdCondition.isSuspicious(),
                         globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -125,8 +125,8 @@ public class VulnerabilityTrendHelper {
             for (GlobalThresholdCondition globalThresholdCondition : globalThresholdConditions) {
                 ThresholdCondition newThresholdCondition = new ThresholdCondition(
                         globalThresholdCondition.getThresholdCount(),
-                        globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(),
-                        thresholdCondition.getApplicationId(), globalThresholdCondition.isAutoRemediated(),
+                        globalThresholdCondition.getThresholdSeverity(), globalThresholdCondition.getThresholdVulnType(), thresholdCondition.getApplicationDefinition(),
+                        thresholdCondition.getApplicationId(),globalThresholdCondition.isAutoRemediated(),
                         globalThresholdCondition.isConfirmed(), globalThresholdCondition.isSuspicious(),
                         globalThresholdCondition.isNotAProblem(), globalThresholdCondition.isRemediated(),
                         globalThresholdCondition.isReported(), globalThresholdCondition.isFixed(), globalThresholdCondition.isBeingTracked(),
@@ -297,8 +297,6 @@ public class VulnerabilityTrendHelper {
                 return "python-contrast.tar.gz";
             case ".NET_CORE":
                 return "dotnet_core-contrast.zip";
-            case "PROXY":
-                return "contrast_security.yml";
             case "JAVA":
             default:
                 return "contrast.jar";

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -257,29 +257,49 @@ public class VulnerabilityTrendHelper {
         items.add("Java", AgentType.JAVA.toString());
         items.add(".NET", AgentType.DOTNET.toString());
         items.add("Node", AgentType.NODE.toString());
+        items.add("Ruby", AgentType.RUBY.toString());
+        items.add("Python", AgentType.PYTHON.toString());
+        items.add(".NET_Core", AgentType.DOTNET_CORE.toString());
+        items.add("Proxy", AgentType.PROXY.toString());
 
         return items;
     }
 
     public static AgentType getAgentTypeFromString(String type) {
-        switch (type) {
+        switch (type.toUpperCase()) {
             case ".NET":
                 return AgentType.DOTNET;
-            case "Node":
+            case "NODE":
                 return AgentType.NODE;
-            case "Java":
+            case "RUBY":
+                return AgentType.RUBY;
+            case "PYTHON":
+                return AgentType.PYTHON;
+            case ".NET_CORE":
+                return AgentType.DOTNET_CORE;
+            case "PROXY":
+                return AgentType.PROXY;
+            case "JAVA":
             default:
                 return AgentType.JAVA;
         }
     }
 
     public static String getDefaultAgentFileNameFromString(String type) {
-        switch (type) {
+        switch (type.toUpperCase()) {
             case ".NET":
                 return "dotnet-contrast.zip";
-            case "Node":
+            case "NODE":
                 return "node-contrast.tgz";
-            case "Java":
+            case "RUBY":
+                return "ruby-contrast.gem";
+            case "PYTHON":
+                return "python-contrast.tar.gz";
+            case ".NET_CORE":
+                return "dotnet_core-contrast.zip";
+            case "PROXY":
+                return "contrast_security.yml";
+            case "JAVA":
             default:
                 return "contrast.jar";
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -2,6 +2,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -118,9 +119,36 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
+            int applicationInstrumentationState = condition.getApplicationDefinition() != null ? condition.getApplicationDefinition().getValue() : 0;
             String appId = condition.getApplicationId();
-            if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
-                appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
+            switch(applicationInstrumentationState){
+                case 1:
+                    try {
+                        Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
+
+                        if (app == null) {
+                            String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", condition.getApplicationOriginName(), condition.getAgentType());
+                            if (profile.isFailOnWrongApplicationId() || condition.isFailOnAppNotFound()) {
+                                throw new AbortException(errorMessage);
+                            } else {
+                                VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+                            }
+                        } else {
+                            condition.setApplicationId(app.getId());
+                            appId = condition.getApplicationId();
+                            VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
+                        }
+                    } catch (UnauthorizedException e) {
+                        VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+                        throw new AbortException("Unable to retrieve application information from TeamServer.");
+                    }
+                    break;
+                case 0:
+                default:
+                    if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
+                        appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
+                    }
+                    break;
             }
 
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
@@ -289,7 +317,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
          * @return String
          */
         public String getDisplayName() {
-            return "Contrast - Verify Vulnerability Threshold";
+            return "Contrast Assess";
         }
 
         /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -119,10 +119,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
-            int applicationInstrumentationState = condition.getApplicationDefinition() != null ? condition.getApplicationDefinition().getValue() : 0;
+
             String appId = condition.getApplicationId();
-            switch(applicationInstrumentationState){
-                case 1:
+            MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
+            switch(matchBy){
+                case APPLICATION_ORIGIN_NAME:
                     try {
                         Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
 
@@ -143,7 +144,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         throw new AbortException("Unable to retrieve application information from TeamServer.");
                     }
                     break;
-                case 0:
+                case APPLICATION_ID:
                 default:
                     if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
                         appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -263,11 +263,16 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                             VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
 
                     if(app == null) {
-                        throw new AbortException("Application with [name = %s, agentType = $s] not found.");
+                        String errorMessage = String.format("Application with [name = %s, agentType = $s] not found.", step.getApplicationName(), step.getAgentType());
+                        if(teamServerProfile.isFailOnWrongApplicationId()) {
+                            throw new AbortException(errorMessage);
+                        } else {
+                            VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
+                        }
+                    } else {
+                        step.setApplicationId(app.getId());
+                        VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : [name = '"+step.getApplicationName()+"', displayName = '"+app.getName()+"', agentType='"+app.getLanguage()+"'] with ID: ["+step.getApplicationId()+"]");
                     }
-
-                    step.setApplicationId(app.getId());
-                    VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : [name = '"+step.getApplicationName()+"', displayName = '"+app.getName()+"', agentType='"+app.getLanguage()+"'] with ID: ["+step.getApplicationId()+"]");
                 } catch (UnauthorizedException | IOException e) {
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
                     throw new AbortException("Unable to retrieve information from TeamServer.");
@@ -275,7 +280,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             }
 
             //// Compatibility fix for plugin versions <=2.6
-            if (step.getApplicationId() == null && step.getApplicationName() != null) {
+            if (step.getApplicationId() == null && step.getApplicationName() != null && step.getAgentType() == null) {
                 for (App app : teamServerProfile.getApps()) {
                     String subStr = app.getTitle().substring(0, app.getTitle().lastIndexOf(" ("));
                     if (subStr.equals(step.getApplicationName())) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -89,31 +89,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     }
 
     /**
-     * Create an application in team server if it does not exist
-     */
-    private boolean createAppIfNotExist;
-
-    @DataBoundSetter
-    public void setCreateAppIfNotExist(boolean createAppIfNotExist) { this.createAppIfNotExist = createAppIfNotExist; }
-
-    /**
      * Type of agent used to instrument the application
      */
     private String agentType;
 
     @DataBoundSetter
     public void setAgentType(String agentType) { this.agentType = agentType; }
-
-    private String applicationCode;
-
-    @DataBoundSetter
-    public void setApplicationCode(String applicationCode) { this.applicationCode = applicationCode; }
-
-    private String applicationPath;
-
-    @DataBoundSetter
-    public void setApplicationPath(String applicationPath) { this.applicationPath = applicationPath; }
-
 
     @DataBoundConstructor
     public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationId, int queryBy) {
@@ -162,14 +143,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         public Step newInstance(Map<String, Object> arguments) {
             VulnerabilityTrendStep step = new VulnerabilityTrendStep();
 
-            if (arguments.containsKey("createAppIfNotExist")) {
-                boolean createAppIfNotExist = (boolean) arguments.get("createAppIfNotExist");
-
-                step.setCreateAppIfNotExist(createAppIfNotExist);
-            } else {
-                step.setCreateAppIfNotExist(false);
-            }
-
             if (arguments.containsKey("profile")) {
                 Object profile = arguments.get("profile");
 
@@ -192,68 +165,29 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             if (arguments.containsKey("rule")) {
                 Object rule = arguments.get("rule");
-
                 step.setRule((String) rule);
             }
 
             if (arguments.containsKey("severity")) {
                 Object severity = arguments.get("severity");
-
                 step.setSeverity((String) severity);
             }
 
             if (arguments.containsKey("applicationId")) {
                 String applicationId = (String) arguments.get("applicationId");
-
-                if (applicationId != null && !step.isCreateAppIfNotExist()) {
-                    step.setApplicationId(applicationId);
-                } else if (step.isCreateAppIfNotExist()) {
-                    if (applicationId == null || applicationId.isEmpty()) {
-                        step.setApplicationId(applicationId);
-                    } else {
-                        throw new IllegalArgumentException("If createAppIfNotExist is true, Application ID must not be set");
-                    }
-                } else {
-                    throw new IllegalArgumentException("Application ID must be set.");
-                }
+                step.setApplicationId(applicationId);
             }
 
-            if (step.isCreateAppIfNotExist() || arguments.containsKey("applicationName")) {
+            if (step.getApplicationId() == null) {
                 Object applicationName = arguments.get("applicationName");
-
-                if (applicationName != null) {
-                    step.setApplicationName((String) applicationName);
-                } else {
-                    throw new IllegalArgumentException("Application name must be set.");
-                }
-            }
-
-            if (step.isCreateAppIfNotExist() || arguments.containsKey("applicationCode")) {
-                Object applicationCode = arguments.get("applicationCode");
-
-                if(applicationCode != null) {
-                    step.setApplicationCode((String) applicationCode);
-                }
-
-                step.setApplicationCode((String) applicationCode);
-
-            }
-
-            if (step.isCreateAppIfNotExist() && arguments.containsKey("applicationPath")) {
-                Object applicationPath = arguments.get("applicationPath");
-
-                if(applicationPath != null) {
-                    step.setApplicationPath((String) applicationPath);
-                }
-            }
-
-            if (step.isCreateAppIfNotExist() || arguments.containsKey("agentType")) {
                 Object agentType = arguments.get("agentType");
-                if(step.isCreateAppIfNotExist() && agentType == null) {
-                    throw new IllegalArgumentException("If createAppIfNotExist is true, Agent Type must be set.");
-                }
 
-                step.setAgentType((String) agentType);
+                if (applicationName != null && agentType != null) {
+                    step.setApplicationName((String) applicationName);
+                    step.setAgentType((String) agentType);
+                } else {
+                    throw new IllegalArgumentException("If Application ID is not set, Application Name and Agent Type must be set.");
+                }
             }
 
             if (arguments.containsKey("queryBy")) {
@@ -322,31 +256,19 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
-            if(step.isCreateAppIfNotExist()) {
+            if(step.getApplicationId() == null) {
                 try {
-                    try {
-                        ApplicationCreateRequest request = new ApplicationCreateRequest(step.getApplicationName(),
-                                VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
-                        request.setAppShortName(step.getApplicationCode());
-                        request.setAppPath(step.getApplicationPath());
+                    Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
+                            step.getApplicationName(),
+                            VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
 
-                        Application app = contrastSDK.createApplication(teamServerProfile.getOrgUuid(), request);
-                        step.setApplicationId(app.getId());
-                        step.setApplicationPath(app.getPath());
-
-                        VulnerabilityTrendHelper.logMessage(taskListener, "Created Application with ID: ["+step.getApplicationId()+"]");
-                    } catch (ApplicationCreateException e) {
-                        if (e.getRc() == 409 && e.getResponseMessage().equals("Application already exists")) {
-                            Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
-                                    step.getApplicationName(),
-                                    VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
-                            step.setApplicationId(app.getId());
-                            VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : ["+ step.getApplicationName()+"] with ID: ["+step.getApplicationId()+"]");
-                        } else {
-                            throw e;
-                        }
+                    if(app == null) {
+                        throw new AbortException("Application with [name = %s, agentType = $s] not found.");
                     }
-                } catch (ApplicationCreateException | UnauthorizedException | IOException e) {
+
+                    step.setApplicationId(app.getId());
+                    VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : [name = '"+step.getApplicationName()+"', displayName = '"+app.getName()+"', agentType='"+app.getLanguage()+"'] with ID: ["+step.getApplicationId()+"]");
+                } catch (UnauthorizedException | IOException e) {
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
                     throw new AbortException("Unable to retrieve information from TeamServer.");
                 }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,9 +1,12 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.aspectsecurity.contrast.contrastjenkins.Constants;
+import com.contrastsecurity.exceptions.ApplicationCreateException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Traces;
+import com.contrastsecurity.models.dtm.ApplicationCreateRequest;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
 import hudson.AbortException;
@@ -85,6 +88,23 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         this.queryBy = queryBy;
     }
 
+    /**
+     * Create an application in team server if it does not exist
+     */
+    private boolean createAppIfNotExist;
+
+    @DataBoundSetter
+    public void setCreateAppIfNotExist(boolean createAppIfNotExist) {this.createAppIfNotExist = createAppIfNotExist; }
+
+    /**
+     * Type of agent used to instrument the application
+     */
+    private String agentType;
+
+    @DataBoundSetter
+    public void setAgentType(String agentType) { this.agentType = agentType.toUpperCase(); }
+
+
     @DataBoundConstructor
     public VulnerabilityTrendStep(String profile, int count, String rule, String severity, String applicationId, int queryBy) {
         this.profile = profile;
@@ -132,6 +152,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         public Step newInstance(Map<String, Object> arguments) {
             VulnerabilityTrendStep step = new VulnerabilityTrendStep();
 
+            if (arguments.containsKey("createAppIfNotExist")) {
+                boolean createAppIfNotExist = (boolean) arguments.get("createAppIfNotExist");
+
+                step.setCreateAppIfNotExist(createAppIfNotExist);
+            } else {
+                step.setCreateAppIfNotExist(false);
+            }
+
             if (arguments.containsKey("profile")) {
                 Object profile = arguments.get("profile");
 
@@ -165,17 +193,22 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             }
 
             if (arguments.containsKey("applicationId")) {
-                Object applicationId = arguments.get("applicationId");
+                String applicationId = (String) arguments.get("applicationId");
 
-                if (applicationId != null) {
-                    step.setApplicationId((String) applicationId);
+                if (applicationId != null && !step.isCreateAppIfNotExist()) {
+                    step.setApplicationId(applicationId);
+                } else if (step.isCreateAppIfNotExist()) {
+                    if (applicationId == null || applicationId.isEmpty()) {
+                        step.setApplicationId(applicationId);
+                    } else {
+                        throw new IllegalArgumentException("If createAppIfNotExist is true, Application ID must not be set");
+                    }
                 } else {
                     throw new IllegalArgumentException("Application ID must be set.");
                 }
-
             }
 
-            if (arguments.containsKey("applicationName")) {
+            if (step.isCreateAppIfNotExist() || arguments.containsKey("applicationName")) {
                 Object applicationName = arguments.get("applicationName");
 
                 if (applicationName != null) {
@@ -183,6 +216,15 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 } else {
                     throw new IllegalArgumentException("Application name must be set.");
                 }
+            }
+
+            if (step.isCreateAppIfNotExist() || arguments.containsKey("agentType")) {
+                Object agentType = arguments.get("agentType");
+                if(step.isCreateAppIfNotExist() && agentType == null) {
+                    throw new IllegalArgumentException("If createAppIfNotExist is true, Agent Type must be set.");
+                }
+
+                step.setAgentType((String) agentType);
             }
 
             if (arguments.containsKey("queryBy")) {
@@ -248,6 +290,38 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 throw new AbortException("Unable to find TeamServer profile.");
             }
 
+            ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
+                    teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
+
+            if(step.isCreateAppIfNotExist()) {
+                try {
+                    try {
+                        ApplicationCreateRequest request = new ApplicationCreateRequest(step.getApplicationName(),
+                                VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
+                        //TODO: add short nam
+                        Application app = contrastSDK.createApplication(teamServerProfile.getOrgUuid(), request);
+                        step.setApplicationId(app.getId());
+                        VulnerabilityTrendHelper.logMessage(taskListener, "Created Application with ID: "+step.getApplicationId());
+                    } catch (ApplicationCreateException e) {
+                        if (e.getRc() == 409 && e.getResponseMessage().equals("Application already exists")) {
+                            Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
+                                    step.getApplicationName(),
+                                    VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
+                            step.setApplicationId(app.getId());
+                            VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : ["+ step.getApplicationName()+"] with ID: ["+step.getApplicationId()+"]");
+                        }
+                        e.printStackTrace();
+                        //TODO: implement
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    //TODO: implement
+                } catch (UnauthorizedException e) {
+                    e.printStackTrace();
+                    //TODO: implement
+                }
+            }
+
             //// Compatibility fix for plugin versions <=2.6
             if (step.getApplicationId() == null && step.getApplicationName() != null) {
                 for (App app : teamServerProfile.getApps()) {
@@ -260,9 +334,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             }
 
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
-
-            ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
-                    teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
             if (!applicationIdExists) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -94,7 +94,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     private boolean createAppIfNotExist;
 
     @DataBoundSetter
-    public void setCreateAppIfNotExist(boolean createAppIfNotExist) {this.createAppIfNotExist = createAppIfNotExist; }
+    public void setCreateAppIfNotExist(boolean createAppIfNotExist) { this.createAppIfNotExist = createAppIfNotExist; }
 
     /**
      * Type of agent used to instrument the application
@@ -103,6 +103,16 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
     @DataBoundSetter
     public void setAgentType(String agentType) { this.agentType = agentType.toUpperCase(); }
+
+    private String applicationCode;
+
+    @DataBoundSetter
+    public void setApplicationCode(String applicationCode) { this.applicationCode = applicationCode; }
+
+    private String applicationPath;
+
+    @DataBoundSetter
+    public void setApplicationPath(String applicationPath) { this.applicationPath = applicationPath; }
 
 
     @DataBoundConstructor
@@ -218,6 +228,25 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 }
             }
 
+            if (step.isCreateAppIfNotExist() || arguments.containsKey("applicationCode")) {
+                Object applicationCode = arguments.get("applicationCode");
+
+                if(applicationCode != null) {
+                    step.setApplicationCode((String) applicationCode);
+                }
+
+                step.setApplicationCode((String) applicationCode);
+
+            }
+
+            if (step.isCreateAppIfNotExist() && arguments.containsKey("applicationPath")) {
+                Object applicationPath = arguments.get("applicationPath");
+
+                if(applicationPath != null) {
+                    step.setApplicationPath((String) applicationPath);
+                }
+            }
+
             if (step.isCreateAppIfNotExist() || arguments.containsKey("agentType")) {
                 Object agentType = arguments.get("agentType");
                 if(step.isCreateAppIfNotExist() && agentType == null) {
@@ -298,10 +327,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     try {
                         ApplicationCreateRequest request = new ApplicationCreateRequest(step.getApplicationName(),
                                 VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
-                        //TODO: add short nam
+                        request.setAppShortName(step.getApplicationCode());
+                        request.setAppPath(step.getApplicationPath());
+
                         Application app = contrastSDK.createApplication(teamServerProfile.getOrgUuid(), request);
                         step.setApplicationId(app.getId());
-                        VulnerabilityTrendHelper.logMessage(taskListener, "Created Application with ID: "+step.getApplicationId());
+                        step.setApplicationPath(app.getPath());
+
+                        VulnerabilityTrendHelper.logMessage(taskListener, "Created Application with ID: ["+step.getApplicationId()+"]");
                     } catch (ApplicationCreateException e) {
                         if (e.getRc() == 409 && e.getResponseMessage().equals("Application already exists")) {
                             Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
@@ -309,16 +342,13 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                                     VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
                             step.setApplicationId(app.getId());
                             VulnerabilityTrendHelper.logMessage(taskListener, "Fetched Application : ["+ step.getApplicationName()+"] with ID: ["+step.getApplicationId()+"]");
+                        } else {
+                            throw e;
                         }
-                        e.printStackTrace();
-                        //TODO: implement
                     }
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    //TODO: implement
-                } catch (UnauthorizedException e) {
-                    e.printStackTrace();
-                    //TODO: implement
+                } catch (ApplicationCreateException | UnauthorizedException | IOException e) {
+                    VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
+                    throw new AbortException("Unable to retrieve information from TeamServer.");
                 }
             }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -102,7 +102,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
     private String agentType;
 
     @DataBoundSetter
-    public void setAgentType(String agentType) { this.agentType = agentType.toUpperCase(); }
+    public void setAgentType(String agentType) { this.agentType = agentType; }
 
     private String applicationCode;
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -180,15 +180,26 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             if (step.getApplicationId() == null) {
                 Object applicationName = arguments.get("applicationName");
-                Object agentType = arguments.get("agentType");
 
-                if (applicationName != null && agentType != null) {
+                if (applicationName != null) {
                     step.setApplicationName((String) applicationName);
-                    step.setAgentType((String) agentType);
                 } else {
-                    throw new IllegalArgumentException("If Application ID is not set, Application Name and Agent Type must be set.");
+                    throw new IllegalArgumentException("If Application ID is not set, Application Name must be set.");
                 }
             }
+
+            if (step.getApplicationId() == null
+                    //// Compatibility fix for plugin versions <=2.6
+                    && arguments.containsKey("agentType")) {
+                Object agentType = arguments.get("agentType");
+
+                if (agentType != null) {
+                    step.setAgentType((String) agentType);
+                } else {
+                    throw new IllegalArgumentException("If Application ID is not set, Agent Type must be set.");
+                }
+            }
+
 
             if (arguments.containsKey("queryBy")) {
                 Object queryBy = arguments.get("queryBy");
@@ -256,14 +267,14 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
-            if(step.getApplicationId() == null) {
+            if(step.getApplicationId() == null && step.getApplicationName() != null && step.getAgentType() != null) {
                 try {
                     Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
                             step.getApplicationName(),
                             VulnerabilityTrendHelper.getAgentTypeFromString(step.getAgentType()));
 
                     if(app == null) {
-                        String errorMessage = String.format("Application with [name = %s, agentType = $s] not found.", step.getApplicationName(), step.getAgentType());
+                        String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", step.getApplicationName(), step.getAgentType());
                         if(teamServerProfile.isFailOnWrongApplicationId()) {
                             throw new AbortException(errorMessage);
                         } else {

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -9,32 +9,26 @@
         <f:entry title="Applications">
                 <f:repeatable field="conditions" add="Add Another Application">
                     <table width="100%">
-                            <h3>Application</h3>
-                            <f:radioBlock checked="${(instance.applicationDefinition == null) ? 'true' : instance.applicationDefinition.value == 0}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has already intrumented my application" value="0">
-                                <f:entry title="Application Id" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
-                                    <f:combobox />
-                                </f:entry>
-                            </f:radioBlock>
-                            <f:radioBlock checked="${instance.applicationDefinition.value == 1}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has not yet instrumented my application. Expect Application Name" value="1" help="">
-                                <f:entry title="Application Name" field="applicationOriginName" help="">
-                                    <f:textbox />
-                                </f:entry>
-                                <f:entry title="Application Language" field="agentType" help="">
-                                    <f:select />
-                                </f:entry>
-                                <f:entry help="">
-                                    <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application" name="doNotFailIfAppNotFound" field="doNotFailIfAppNotFound" />
-                                </f:entry>
-                            </f:radioBlock>
-                            <!-- feature flagged
-                            <f:radioBlock checked="${instance.applicationDefinition.value == 2}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has not yet instrumented my application. Expect Application Code" value="2" help="">
-                                <f:entry title="Application Code" field="applicationShortName" help="">
-                                    <f:textbox />
-                                </f:entry>
-                                <f:entry help="">
-                                    <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application" name="doNotFailIfAppNotFound" field="doNotFailIfAppNotFound" />
-                                </f:entry>
-                            </f:radioBlock> -->
+                        <f:radioBlock checked="${(instance.applicationState == null) ? 'true' : instance.applicationState == 0}" name="${instance.hashCode()}.applicationState" title="Contrast has already intrumented my application" value="0" inline="true">
+                            <f:entry title="Choose your application" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
+                                <f:combobox />
+                            </f:entry>
+                        </f:radioBlock>
+                        <f:radioBlock checked="${instance.applicationState == 1}" name="${instance.hashCode()}.applicationState" title="Contrast has not yet instrumented my application" value="1" help="" inline="true">
+                            <f:dropdownList name="applicationDefinition"> <!-- dropdownlist is not sending value, base persistence on the existance of fields -->
+                                <f:dropdownListBlock title="Expected Application Name" selected="${instance.applicationDefinition.applicationOriginName != null}" value="0">
+                                    <f:entry title="Expected Application Name" field="applicationOriginName" help="">
+                                        <f:textbox />
+                                    </f:entry>
+                                    <f:entry title="Application Language" field="agentType" help="">
+                                        <f:select />
+                                    </f:entry>
+                                    <f:entry help="">
+                                        <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application with name and language provided" name="failOnAppNotFound" field="failOnAppNotFound" />
+                                    </f:entry>
+                                </f:dropdownListBlock>
+                            </f:dropdownList>
+                        </f:radioBlock>
 
                         <f:entry title="Count" field="thresholdCount"
                                  help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
@@ -108,7 +102,13 @@
         </f:entry>
     </f:section>
     <style>
+        #jenkins .jenkins-config table .repeated-chunk, #jenkins .jenkins-config table tr[nameref^="rowSetStart"], #jenkins .jenkins-config table tr[nameref^="cb"], #jenkins .jenkins-config table tr[nameref^="radio-block"] {
+            border : none;
+        }
 
+        #jenkins .jenkins-config table .hetero-list-container, #jenkins .jenkins-config table .repeated-container, #jenkins .jenkins-config table tr.optional-block-start, #jenkins .jenkins-config table tr.radio-block-start {
+            border : none;
+        }
     </style>
     <script>
         var overrideGlobalThresholdConditionsCheckboxElements =
@@ -128,6 +128,7 @@
         var suspiciousElements = document.getElementsByName("suspicious");
         var reportedElements = document.getElementsByName("reported");
         var untrackedElements = document.getElementsByName("untracked");
+        var conditionTitle = document.getElementsByName("conditionTitle");
 
         var dynamicElements = [];
         dynamicElements.push(thresholdCountElements);

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -14,16 +14,16 @@
                                 <f:combobox />
                             </f:entry>
                         </f:radioBlock>
-                        <f:radioBlock checked="${instance.applicationState == 1}" name="${instance.hashCode()}.applicationState" title="Contrast has not yet instrumented my application" value="1" help="" inline="true">
+                        <f:radioBlock checked="${instance.applicationState == 1}" name="${instance.hashCode()}.applicationState" title="Contrast has not yet instrumented my application" value="1" help="/plugin/contrast-continuous-application-security/help-applicationNotInstrumented.html" inline="true">
                             <f:dropdownList name="applicationDefinition"> <!-- dropdownlist is not sending value, base persistence on the existance of fields -->
                                 <f:dropdownListBlock title="Expected Application Name" selected="${instance.applicationDefinition.applicationOriginName != null}" value="0">
-                                    <f:entry title="Expected Application Name" field="applicationOriginName" help="">
+                                    <f:entry title="Application Name" field="applicationOriginName" help="/plugin/contrast-continuous-application-security/help-applicationName.html">
                                         <f:textbox />
                                     </f:entry>
-                                    <f:entry title="Application Language" field="agentType" help="">
+                                    <f:entry title="Application Language" field="agentType">
                                         <f:select />
                                     </f:entry>
-                                    <f:entry help="">
+                                    <f:entry>
                                         <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application with name and language provided" name="failOnAppNotFound" field="failOnAppNotFound" />
                                     </f:entry>
                                 </f:dropdownListBlock>

--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -1,11 +1,94 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
 
-    <f:section title="Vulnerability Threshold Conditions">
-        <f:entry title="TeamServer Profile" field="teamServerProfileName">
+    <f:section title="Application Vulnerability Security Controls">
+        <f:entry title="Contrast Connection" field="teamServerProfileName">
             <f:select/>
         </f:entry>
 
+        <f:entry title="Applications">
+                <f:repeatable field="conditions" add="Add Another Application">
+                    <table width="100%">
+                            <h3>Application</h3>
+                            <f:radioBlock checked="${(instance.applicationDefinition == null) ? 'true' : instance.applicationDefinition.value == 0}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has already intrumented my application" value="0">
+                                <f:entry title="Application Id" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
+                                    <f:combobox />
+                                </f:entry>
+                            </f:radioBlock>
+                            <f:radioBlock checked="${instance.applicationDefinition.value == 1}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has not yet instrumented my application. Expect Application Name" value="1" help="">
+                                <f:entry title="Application Name" field="applicationOriginName" help="">
+                                    <f:textbox />
+                                </f:entry>
+                                <f:entry title="Application Language" field="agentType" help="">
+                                    <f:select />
+                                </f:entry>
+                                <f:entry help="">
+                                    <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application" name="doNotFailIfAppNotFound" field="doNotFailIfAppNotFound" />
+                                </f:entry>
+                            </f:radioBlock>
+                            <!-- feature flagged
+                            <f:radioBlock checked="${instance.applicationDefinition.value == 2}" name="${instance.hashCode()}.applicationDefinition" title="Contrast has not yet instrumented my application. Expect Application Code" value="2" help="">
+                                <f:entry title="Application Code" field="applicationShortName" help="">
+                                    <f:textbox />
+                                </f:entry>
+                                <f:entry help="">
+                                    <f:checkbox checked="${(instance.failOnAppNotFound == null) ? 'true' : instance.failOnAppNotFound}" title="Fail my Jenkins job if Contrast is unable to find my application" name="doNotFailIfAppNotFound" field="doNotFailIfAppNotFound" />
+                                </f:entry>
+                            </f:radioBlock> -->
+
+                        <f:entry title="Count" field="thresholdCount"
+                                 help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
+                            <f:number name="thresholdCount" field="thresholdCount" default="0"
+                                      clazz="required positive-number"/>
+                        </f:entry>
+
+                        <f:entry title="Severity" field="thresholdSeverity"
+                                 help="/plugin/contrast-continuous-application-security/help-thresholdSeverity.html">
+                            <f:select/>
+                        </f:entry>
+
+                        <f:entry title="Vulnerability Type" field="thresholdVulnType"
+                                 help="/plugin/contrast-continuous-application-security/help-thresholdVulnType.html">
+                            <f:select/>
+                        </f:entry>
+
+                        <f:entry title="Vulnerability statuses" help="/plugin/contrast-continuous-application-security/help-vulnerabilityStatus.html">
+                            <f:checkbox title="Auto-Remediated" name="autoRemediated" field="autoRemediated"/>
+                        </f:entry>
+
+                        <f:entry>
+                            <f:checkbox title="Not a Problem" name="notAProblem" field="notAProblem"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Fixed" name="fixed" field="fixed"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Confirmed" name="confirmed" field="confirmed"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Remediated" name="remediated" field="remediated"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Being Tracked" name="beingTracked" field="beingTracked"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Suspicious" name="suspicious" field="suspicious"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Reported" name="reported" field="reported"/>
+                        </f:entry>
+                        <f:entry>
+                            <f:checkbox title="Untracked" name="untracked" field="untracked"/>
+                        </f:entry>
+
+                        <f:entry title="">
+                            <div align="right">
+                                <f:repeatableDeleteButton/>
+                            </div>
+                        </f:entry>
+                    </table>
+                </f:repeatable>
+        </f:entry>
         <f:entry title="Query vulnerabilities by" field="queryBy" >
             <f:entry>
                 <f:radio name="queryBy" title="appVersionTag, format: applicationId-buildNumber" value="1" checked="true" />
@@ -20,73 +103,13 @@
                 <f:radio name="queryBy" title="Parameter: APPVERSIONTAG" value="4" checked="${instance.queryBy == 4}" />
             </f:entry>
         </f:entry>
-
         <f:entry>
-            <f:checkbox title="Override Global Threshold Conditions" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
-        </f:entry>
-
-
-        <f:entry description="Conditions for verifying your build">
-            <f:repeatable field="conditions">
-                <table width="100%">
-                    <f:entry title="Application Id" help="/plugin/contrast-continuous-application-security/help-applicationId.html" field="applicationId">
-                        <f:combobox />
-                    </f:entry>
-
-                    <f:entry title="Count" field="thresholdCount"
-                             help="/plugin/contrast-continuous-application-security/help-thresholdCount.html">
-                        <f:number name="thresholdCount" field="thresholdCount" default="0"
-                                  clazz="required positive-number"/>
-                    </f:entry>
-
-                    <f:entry title="Severity" field="thresholdSeverity"
-                             help="/plugin/contrast-continuous-application-security/help-thresholdSeverity.html">
-                        <f:select/>
-                    </f:entry>
-
-                    <f:entry title="Vulnerability Type" field="thresholdVulnType"
-                             help="/plugin/contrast-continuous-application-security/help-thresholdVulnType.html">
-                        <f:select/>
-                    </f:entry>
-
-                    <f:entry title="Vulnerability statuses" help="/plugin/contrast-continuous-application-security/help-vulnerabilityStatus.html">
-                        <f:checkbox title="Auto-Remediated" name="autoRemediated" field="autoRemediated"/>
-                    </f:entry>
-
-                    <f:entry>
-                        <f:checkbox title="Not a Problem" name="notAProblem" field="notAProblem"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Fixed" name="fixed" field="fixed"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Confirmed" name="confirmed" field="confirmed"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Remediated" name="remediated" field="remediated"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Being Tracked" name="beingTracked" field="beingTracked"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Suspicious" name="suspicious" field="suspicious"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Reported" name="reported" field="reported"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:checkbox title="Untracked" name="untracked" field="untracked"/>
-                    </f:entry>
-
-                    <f:entry title="">
-                        <div align="right">
-                            <f:repeatableDeleteButton/>
-                        </div>
-                    </f:entry>
-                </table>
-            </f:repeatable>
+            <f:checkbox title="Override Vulenrability Security Controls at the Jenkins system level" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
         </f:entry>
     </f:section>
+    <style>
+
+    </style>
     <script>
         var overrideGlobalThresholdConditionsCheckboxElements =
         document.getElementsByName("overrideGlobalThresholdConditions");

--- a/src/main/webapp/help-applicationName.html
+++ b/src/main/webapp/help-applicationName.html
@@ -1,0 +1,3 @@
+<div>
+    The application name that you will provide to the Contrast agent during application startup to begin instrumentation.
+</div>

--- a/src/main/webapp/help-applicationNotInstrumented.html
+++ b/src/main/webapp/help-applicationNotInstrumented.html
@@ -1,0 +1,5 @@
+<div>
+    Contrast will not know of your application's existence if it has not yet been run with the Contrast agent.
+    In this case, enter your application name and language. If the application display name is different from the application name, use the application name.
+    The Contrast-Jenkins plugin will query Contrast for vulnerability information using the exact name provided.
+</div>

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdConditionStub.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdConditionStub.java
@@ -4,7 +4,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 public class ThresholdConditionStub extends ThresholdCondition {
 
     public ThresholdConditionStub() {
-        super(0, "test", "test", "test",
+        super(0, "test", "test", null,"test",
                 false, false,false, false, false, false,
                 false, false, false);
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdConditionStub.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdConditionStub.java
@@ -4,7 +4,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 public class ThresholdConditionStub extends ThresholdCondition {
 
     public ThresholdConditionStub() {
-        super(0, "test", "test", null,"test",
+        super(0, "test", "test", 0,null,"test",
                 false, false,false, false, false, false,
                 false, false, false);
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -1,6 +1,7 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.TraceFilter;
@@ -10,6 +11,7 @@ import hudson.AbortException;
 import hudson.Launcher;
 import hudson.model.*;
 import jenkins.model.Jenkins;
+import org.apache.xerces.impl.xpath.regex.Match;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -190,6 +192,94 @@ public class VulnerabilityTrendRecorderTest {
         when(build.getNumber()).thenReturn(1);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
+    }
+
+    @Test
+    public void testSuccessfulBuildWithAppNameAppFound() throws Exception {
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
+        when(thresholdCondition.getMatchBy()).thenReturn(MatchBy.APPLICATION_ORIGIN_NAME);
+        when(thresholdCondition.getThresholdCount()).thenReturn(0);
+        when(thresholdCondition.getThresholdSeverity()).thenReturn(null);
+        when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
+        when(thresholdCondition.getApplicationOriginName()).thenReturn("test");
+        when(thresholdCondition.getAgentType()).thenReturn("testlang");
+        when(thresholdCondition.isFailOnAppNotFound()).thenReturn(true);
+        conditions.add(thresholdCondition);
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(0);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getName()).willReturn("local");
+        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+
+        Application application = mock(Application.class);
+        when(application.getId()).thenReturn("testId");
+
+        when(contrastSDKMock.getApplicationByNameAndLanguage(anyString(), anyString(), any(AgentType.class))).thenReturn(application);
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(1);
+
+        assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
+    }
+
+    @Test(expected = AbortException.class)
+    public void testUnSuccessfulBuildAppNameAppNotFound() throws Exception {
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        ThresholdCondition thresholdCondition = mock(ThresholdCondition.class);
+        when(thresholdCondition.getMatchBy()).thenReturn(MatchBy.APPLICATION_ORIGIN_NAME);
+        when(thresholdCondition.getThresholdCount()).thenReturn(0);
+        when(thresholdCondition.getThresholdSeverity()).thenReturn(null);
+        when(thresholdCondition.getThresholdVulnType()).thenReturn(null);
+        when(thresholdCondition.getApplicationOriginName()).thenReturn("test");
+        when(thresholdCondition.getAgentType()).thenReturn("testlang");
+        when(thresholdCondition.isFailOnAppNotFound()).thenReturn(true);
+        conditions.add(thresholdCondition);
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+                "test", true, Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(0);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getName()).willReturn("local");
+        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+
+        when(contrastSDKMock.getApplicationByNameAndLanguage(anyString(), anyString(), any(AgentType.class))).thenReturn(null); //app not found
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(1);
+
+        vulnerabilityTrendRecorder.perform(build, launcher, listener);
+
     }
 
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -316,8 +316,8 @@ public class VulnerabilityTrendRecorderTest {
         final String appName = "WebGoat";
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
-        ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All",
-                appName, true, true, true, true, true,
+        ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All", null,
+                "test", true, true, true, true, true,
                 true, true, true, true);
         conditions.add(thresholdCondition);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -316,7 +316,7 @@ public class VulnerabilityTrendRecorderTest {
         final String appName = "WebGoat";
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
-        ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All", null,
+        ThresholdCondition thresholdCondition = new ThresholdCondition(1, "High", "All", 0,null,
                 "test", true, true, true, true, true,
                 true, true, true, true);
         conditions.add(thresholdCondition);


### PR DESCRIPTION
# Problem
User has to run the job twice in order to fully configure a job if the application is new. Once to allow the application to be instrumented and created in Team Server. The user then has to reconfigure the job to select the application that was just created.

# Solution
Allow the user to select the application using the name and language.

# Summary of Changes
1. Implemented new agent types.

## Pipeline
1. Add agentType parameter - "type of agent that is going to be used to instrument the application"
1. If Application Id is not defined and agentType is defined, the Application Name and AgentType is used to select the application.


## Post Build Step
1. Added MatchBy enum to define how to match/select an application.
1. Added ApplicationDefinition as a wrapper for definition of the application when the application is not yet instrumented.
1. Renamed Titles in UI
1. Modified VulnerabilityTrendRecorder to perform based on MatchBy enum.
