### PR TITLE
Contrast 39402 security check with application and params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
     <dependency>
       <groupId>com.contrastsecurity</groupId>
       <artifactId>contrast-sdk-java</artifactId>
-      <version>2.12</version>
+      <!-- TODO: Fix Me -->
+      <version>2.13-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -3,10 +3,12 @@ package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.RuleSeverity;
+import com.contrastsecurity.http.SecurityCheckForm;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.*;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.ProxyConfiguration;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ComboBoxModel;
@@ -524,6 +526,38 @@ public class VulnerabilityTrendHelper {
         }
 
         return apps;
+    }
+
+    public static SecurityCheck makeSecurityCheck(ContrastSDK sdk, String organizationUuid, String applicationName, String agentType, TraceFilterForm filterForm, int queryBy) throws IOException, UnauthorizedException {
+        SecurityCheckForm form = new SecurityCheckForm(applicationName, getAgentTypeFromString(agentType));
+        switch(queryBy) {
+            case Constants.QUERY_BY_START_DATE:
+                form.setStartDate(filterForm.getStartDate().getTime());
+                break;
+            case Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT:
+            case Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT:
+            case Constants.QUERY_BY_PARAMETER:
+                if(!filterForm.getAppVersionTags().contains("")) { //don't set filter if empty string is set to match behavior of local security controls.
+                    form.setAppVersionTags(filterForm.getAppVersionTags());
+                }
+                break;
+            default:
+                //#noFilter
+        }
+        return sdk.makeSecurityCheck(organizationUuid, form);
+    }
+
+    public static Result getJenkinsResultFromJobOutcome(JobOutcomePolicy.Outcome outcome) throws VulnerabilityTrendHelperException {
+        switch(outcome) {
+            case FAIL:
+                return Result.FAILURE;
+            case SUCCESS:
+                return Result.SUCCESS;
+            case UNSTABLE:
+                return Result.UNSTABLE;
+            default:
+                throw new VulnerabilityTrendHelperException("Unrecognized Job Outcome Policy Outcome: " + outcome.toString());
+        }
     }
 
     public static final String EMPTY_SELECT = "All";

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -528,8 +528,8 @@ public class VulnerabilityTrendHelper {
         return apps;
     }
 
-    public static SecurityCheck makeSecurityCheck(ContrastSDK sdk, String organizationUuid, String applicationName, String agentType, TraceFilterForm filterForm, int queryBy) throws IOException, UnauthorizedException {
-        SecurityCheckForm form = new SecurityCheckForm(applicationName, getAgentTypeFromString(agentType));
+    public static SecurityCheck makeSecurityCheck(ContrastSDK sdk, String organizationUuid, String applicationId, TraceFilterForm filterForm, int queryBy) throws IOException, UnauthorizedException {
+        SecurityCheckForm form = new SecurityCheckForm(applicationId);
         switch(queryBy) {
             case Constants.QUERY_BY_START_DATE:
                 form.setStartDate(filterForm.getStartDate().getTime());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -556,7 +556,7 @@ public class VulnerabilityTrendHelper {
             case UNSTABLE:
                 return Result.UNSTABLE;
             default:
-                throw new VulnerabilityTrendHelperException("Unrecognized Job Outcome Policy Outcome: " + outcome.toString());
+                throw new VulnerabilityTrendHelperException("Unrecognized Job Outcome: " + outcome.toString());
         }
     }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperException.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperException.java
@@ -1,0 +1,7 @@
+package com.aspectsecurity.contrast.contrastjenkins;
+
+public class VulnerabilityTrendHelperException extends Exception {
+  public VulnerabilityTrendHelperException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -87,6 +87,69 @@ public class VulnerabilityTrendRecorder extends Recorder {
         return this;
     }
 
+    private TraceFilterForm buildFilterFormForCondition(ThresholdCondition condition, AbstractBuild<?, ?> build, String appId) {
+        TraceFilterForm filterForm = new TraceFilterForm();
+
+        if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+            String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, appId);
+
+            List<String> appVersionTagsList = new ArrayList<>();
+            appVersionTagsList.add(appVersionTag);
+
+            if (condition.getApplicationName() != null) {
+                String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
+                appVersionTagsList.add(appVersionTagAppName);
+            }
+
+            filterForm.setAppVersionTags(appVersionTagsList);
+        } else if (queryBy == Constants.QUERY_BY_START_DATE) {
+            filterForm.setStartDate(build.getTime());
+        } else if (queryBy == Constants.QUERY_BY_PARAMETER) {
+            final EnvVars env = build.getEnvironment(listener);
+            String appVersionTag;
+
+            if (env.get("APPVERSIONTAG") != null) {
+                appVersionTag = env.get("APPVERSIONTAG");
+            } else {
+                appVersionTag = "";
+            }
+
+            if (appVersionTag.isEmpty()) {
+                VulnerabilityTrendHelper.logMessage(listener, "Warning: queryBy Parameter is configured, but APPVERSIONTAG is not set. All vulnerabilities will be returned for this application.");
+            }
+
+            List<String> appVersionTagsList = new ArrayList<>();
+            appVersionTagsList.add(appVersionTag);
+
+            filterForm.setAppVersionTags(appVersionTagsList);
+        } else {
+            String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, appId);
+
+            List<String> appVersionTagsList = new ArrayList<>();
+            appVersionTagsList.add(appVersionTag);
+
+            if (condition.getApplicationName() != null) {
+                String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
+                appVersionTagsList.add(appVersionTagAppName);
+            }
+
+            filterForm.setAppVersionTags(appVersionTagsList);
+        }
+
+        if (condition.getThresholdSeverity() != null) {
+            filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(condition.getThresholdSeverity()));
+        }
+
+        if (condition.getThresholdVulnType() != null) {
+            filterForm.setVulnTypes(Collections.singletonList(condition.getThresholdVulnType()));
+        }
+
+        if (!condition.getVulnerabilityStatuses().isEmpty()) {
+            filterForm.setStatus(condition.getVulnerabilityStatuses());
+        }
+        return filterForm;
+    }
+
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
 
@@ -159,69 +222,14 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     throw new AbortException("Application with ID '" + appId + "' not found.");
                 }
             } else {
+
+                TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId);
+                VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
+
                 VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
 
                 try {
-                    TraceFilterForm filterForm = new TraceFilterForm();
 
-                    if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
-                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, appId);
-
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-
-                        if (condition.getApplicationName() != null) {
-                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, condition.getApplicationName());
-                            appVersionTagsList.add(appVersionTagAppName);
-                        }
-
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    } else if (queryBy == Constants.QUERY_BY_START_DATE) {
-                        filterForm.setStartDate(build.getTime());
-                    } else if (queryBy == Constants.QUERY_BY_PARAMETER) {
-                        final EnvVars env = build.getEnvironment(listener);
-                        String appVersionTag;
-
-                        if (env.get("APPVERSIONTAG") != null) {
-                            appVersionTag = env.get("APPVERSIONTAG");
-                        } else {
-                            appVersionTag = "";
-                        }
-
-                        if (appVersionTag.isEmpty()) {
-                            VulnerabilityTrendHelper.logMessage(listener, "Warning: queryBy Parameter is configured, but APPVERSIONTAG is not set. All vulnerabilities will be returned for this application.");
-                        }
-
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-                        
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    } else {
-                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, appId);
-
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-
-                        if (condition.getApplicationName() != null) {
-                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, condition.getApplicationName());
-                            appVersionTagsList.add(appVersionTagAppName);
-                        }
-
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    }
-
-                    if (condition.getThresholdSeverity() != null) {
-                        filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(condition.getThresholdSeverity()));
-                    }
-
-                    if (condition.getThresholdVulnType() != null) {
-                        filterForm.setVulnTypes(Collections.singletonList(condition.getThresholdVulnType()));
-                    }
-
-                    if (!condition.getVulnerabilityStatuses().isEmpty()) {
-                        filterForm.setStatus(condition.getVulnerabilityStatuses());
-                    }
-                    VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                     if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
                         traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
                     } else {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -87,7 +87,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
         return this;
     }
 
-    private TraceFilterForm buildFilterFormForCondition(ThresholdCondition condition, AbstractBuild<?, ?> build, String appId) {
+    private TraceFilterForm buildFilterFormForCondition(final ThresholdCondition condition, final AbstractBuild<?, ?> build, final String appId, final BuildListener listener) throws IOException, InterruptedException {
         TraceFilterForm filterForm = new TraceFilterForm();
 
         if (queryBy == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
@@ -223,7 +223,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 }
             } else {
 
-                TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId);
+                TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
                 VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
 
                 VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -226,36 +227,55 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
                 VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
 
-                VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
+
 
                 try {
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId, filterForm, queryBy);
 
-                    if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
-                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
+                    if(securityCheck.getResult() != null) {
+                        VulnerabilityTrendHelper.logMessage(listener,"Warning: A job outcome policy was defined for ["+appId+"], overriding security controls");
+
+                        if(securityCheck.getResult()) { //failed a policy
+                            VulnerabilityTrendHelper.logMessage(listener, "This application has passed all applicable job outcome policy");
+                            return true;
+                        } else {
+                            try {
+                                Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
+                                VulnerabilityTrendHelper.logMessage(listener,"This application ["+appId+"] has failed the job outcome policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
+                                build.setResult(jobResult);
+                                return true;
+                            } catch (VulnerabilityTrendHelperException e) {
+                                throw new AbortException(e.getMessage());
+                            }
+                        }
                     } else {
-                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
+                        VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
+                        if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
+                        } else {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
+                        }
+                        resultTraces.addAll(traces.getTraces());
+                        int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
+
+                        if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
+                            // save results before failing build
+                            buildResult(resultTraces, build);
+
+                            Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
+                            VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
+                            VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                            if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                                throw new AbortException("Failed on the threshold condition where " + condition.toString());
+                            } else {
+                                build.setResult(buildResult);
+                                return true;
+                            }
+                        }
                     }
                 } catch (UnauthorizedException e) {
                     VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
                     throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
-                }
-
-                resultTraces.addAll(traces.getTraces());
-                int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
-
-                if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
-                    // save results before failing build
-                    buildResult(resultTraces, build);
-
-                    Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
-                    VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
-                    VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                    if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                        throw new AbortException("Failed on the threshold condition where " + condition.toString());
-                    } else {
-                        build.setResult(buildResult);
-                        return true;
-                    }
                 }
             }
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -154,16 +154,13 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     throw new IllegalArgumentException("Profile must be set.");
                 }
             }
-            //TODO: Add a condition to skip this validation if the selected app has JOP? -- need a way to know if profile has JOP
-            //TODO: Remove validation and default count to 0 and log warning?
 
             if (arguments.containsKey("count")) {
                 Object count = arguments.get("count");
-
                 if (count != null) {
                     step.setCount((int) count);
                 } else {
-                    throw new IllegalArgumentException("Count must be set.");
+                    step.setCount(-1);
                 }
             }
 
@@ -315,7 +312,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
         @Override
         public Void run() throws AbortException, InterruptedException {
-
             TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(step.getProfile());
 
             if (teamServerProfile == null) {
@@ -374,8 +370,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 String stepString = step.buildStepString();
 
                 try {
-                    //TODO: change security check to use ID.
-
                     //makeFilterForm
                     TraceFilterForm filterForm = makeFilterFormWithQueryBy();
 
@@ -396,6 +390,12 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                             VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                         }
                     } else { //regular verify
+
+                        //set default for count if not set
+                        if(step.getCount() == -1 ) {
+                            throw new IllegalArgumentException("Count is required for applications without a job outcome policy defined.");
+                        }
+
                         VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
 
                         Traces traces;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -374,7 +374,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     if(securityCheck.getResult() != null) { // jop is defined for app
                         VulnerabilityTrendHelper.logMessage(taskListener,"Warning: A job outcome policy was defined for ["+step.getApplicationId()+"], overriding security controls");
                         VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
-                        if(!securityCheck.getResult()) { //failed a policy
+                        if(securityCheck.getResult()) { //failed a policy
+                            VulnerabilityTrendHelper.logMessage(taskListener, "This application has passed all applicable job outcome policy");
+                        } else {
                             try {
                                 Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
                                 VulnerabilityTrendHelper.logMessage(taskListener,"This application ["+step.getApplicationId()+"] has failed the job outcome policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
@@ -382,8 +384,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                             } catch (VulnerabilityTrendHelperException e) {
                                 throw new AbortException(e.getMessage());
                             }
-                        } else {
-                            VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                         }
                     } else { //regular verify
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -157,11 +157,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             if (arguments.containsKey("count")) {
                 Object count = arguments.get("count");
-                if (count != null) {
-                    step.setCount((int) count);
-                } else {
-                    step.setCount(-1);
-                }
+                step.setCount((int) count);
             }
 
             if (arguments.containsKey("rule")) {
@@ -390,11 +386,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                             VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                         }
                     } else { //regular verify
-
-                        //set default for count if not set
-                        if(step.getCount() == -1 ) {
-                            throw new IllegalArgumentException("Count is required for applications without a job outcome policy defined.");
-                        }
 
                         VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -1,12 +1,9 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
-import com.aspectsecurity.contrast.contrastjenkins.Constants;
-import com.contrastsecurity.exceptions.ApplicationCreateException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Traces;
-import com.contrastsecurity.models.dtm.ApplicationCreateRequest;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
 import hudson.AbortException;
@@ -18,7 +15,11 @@ import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import lombok.Getter;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.inject.Inject;
@@ -153,6 +154,8 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     throw new IllegalArgumentException("Profile must be set.");
                 }
             }
+            //TODO: Add a condition to skip this validation if the selected app has JOP? -- need a way to know if profile has JOP
+            //TODO: Remove validation and default count to 0 and log warning?
 
             if (arguments.containsKey("count")) {
                 Object count = arguments.get("count");
@@ -255,6 +258,61 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         @Inject
         transient VulnerabilityTrendStep step;
 
+        private TraceFilterForm makeFilterFormWithQueryBy() throws IOException, InterruptedException {
+            TraceFilterForm filterForm = new TraceFilterForm();
+
+            if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+
+                String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId());
+
+                List<String> appVersionTagsList = new ArrayList<>();
+                appVersionTagsList.add(appVersionTag);
+
+                if (step.getApplicationName() != null) {
+                    String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
+                    appVersionTagsList.add(appVersionTagAppName);
+                }
+
+                filterForm.setAppVersionTags(appVersionTagsList);
+            } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
+                filterForm.setStartDate(build.getTime());
+            } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
+                final EnvVars env = build.getEnvironment(taskListener);
+                String appVersionTag;
+
+                if (step.getAppVersionTag() != null) {
+                    appVersionTag = step.getAppVersionTag();
+                } else if (env.get("APPVERSIONTAG") != null) {
+                    appVersionTag = env.get("APPVERSIONTAG");
+                } else {
+                    appVersionTag = "";
+                }
+
+                if (appVersionTag.isEmpty()) {
+                    VulnerabilityTrendHelper.logMessage(taskListener, "Warning: queryBy Parameter is configured, but appVersionTag is not set. All vulnerabilities will be returned for this application.");
+                }
+
+                List<String> appVersionTagsList = new ArrayList<>();
+                appVersionTagsList.add(appVersionTag);
+
+                filterForm.setAppVersionTags(appVersionTagsList);
+            } else {
+                String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
+
+                List<String> appVersionTagsList = new ArrayList<>();
+                appVersionTagsList.add(appVersionTag);
+
+                if (step.getApplicationName() != null) {
+                    String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName());
+                    appVersionTagsList.add(appVersionTagAppName);
+                }
+
+                filterForm.setAppVersionTags(appVersionTagsList);
+            }
+
+            return filterForm;
+        }
+
         @Override
         public Void run() throws AbortException, InterruptedException {
 
@@ -268,6 +326,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 
+            //Convert app name and agent type to app id
             if(step.getApplicationId() == null && step.getApplicationName() != null && step.getAgentType() != null) {
                 try {
                     Application app = contrastSDK.getApplicationByNameAndLanguage(teamServerProfile.getOrgUuid(),
@@ -291,6 +350,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 }
             }
 
+            // Convert app display name to app id
             //// Compatibility fix for plugin versions <=2.6
             if (step.getApplicationId() == null && step.getApplicationName() != null && step.getAgentType() == null) {
                 for (App app : teamServerProfile.getApps()) {
@@ -301,9 +361,8 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     }
                 }
             }
-
+            //validation
             VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
-
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
             if (!applicationIdExists) {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Application with ID '" + step.getApplicationId() + "' not found.");
@@ -311,96 +370,67 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     throw new AbortException("Application with ID '" + step.getApplicationId() + "' not found.");
                 }
             } else {
-                Traces traces;
 
                 String stepString = step.buildStepString();
 
-                VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
-
                 try {
-                    TraceFilterForm filterForm = new TraceFilterForm();
+                    //TODO: change security check to use ID.
 
-                    if (step.getQueryBy() == Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT) {
+                    //makeFilterForm
+                    TraceFilterForm filterForm = makeFilterFormWithQueryBy();
 
-                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationId());
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationName(), step.getAgentType(), filterForm, step.getQueryBy());
 
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-
-                        if (step.getApplicationName() != null) {
-                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, step.getApplicationName());
-                            appVersionTagsList.add(appVersionTagAppName);
-                        }
-
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                        filterForm.setStartDate(build.getTime());
-                    } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
-                        final EnvVars env = build.getEnvironment(taskListener);
-                        String appVersionTag;
-
-                        if (step.getAppVersionTag() != null) {
-                            appVersionTag = step.getAppVersionTag();
-                        } else if (env.get("APPVERSIONTAG") != null) {
-                            appVersionTag = env.get("APPVERSIONTAG");
+                    if(securityCheck.getResult() != null) { // jop is defined for app
+                        VulnerabilityTrendHelper.logMessage(taskListener,"Warning: A job outcome policy was defined for ["+step.getApplicationId()+"], overriding security controls");
+                        if(!securityCheck.getResult()) { //failed a policy
+                            try {
+                                Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
+                                VulnerabilityTrendHelper.logMessage(taskListener,"This application ["+step.getApplicationId()+"] has failed the job outcome policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
+                                build.setResult(jobResult);
+                            } catch (VulnerabilityTrendHelperException e) {
+                                throw new AbortException(e.getMessage());
+                            }
                         } else {
-                            appVersionTag = "";
+                            VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
+                        }
+                    } else { //regular verify
+                        VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
+
+                        Traces traces;
+
+                        if (step.getSeverity() != null) {
+                            filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(step.getSeverity()));
                         }
 
-                        if (appVersionTag.isEmpty()) {
-                            VulnerabilityTrendHelper.logMessage(taskListener, "Warning: queryBy Parameter is configured, but appVersionTag is not set. All vulnerabilities will be returned for this application.");
+                        if (step.getRule() != null) {
+                            filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
+                        }
+                        VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
+                        if (step.getQueryBy() == Constants.QUERY_BY_START_DATE || step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
+                        } else {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), null, filterForm);
                         }
 
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-                        
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    } else {
-                        String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationId());
+                        if (traces.getCount() > step.getCount()) {
+                            Result buildResult = Result.fromString(teamServerProfile.getVulnerableBuildResult());
+                            VulnerabilityTrendHelper.logMessage(taskListener, "Failed on the condition where " + stepString);
+                            VulnerabilityTrendHelper.logMessage(taskListener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                            if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                                throw new AbortException("Failed on the condition where " + stepString);
+                            } else {
+                                build.setResult(buildResult);
+                                return null;
+                            }
 
-                        List<String> appVersionTagsList = new ArrayList<>();
-                        appVersionTagsList.add(appVersionTag);
-
-                        if (step.getApplicationName() != null) {
-                            String appVersionTagAppName = VulnerabilityTrendHelper.buildAppVersionTag(build, step.getApplicationName());
-                            appVersionTagsList.add(appVersionTagAppName);
                         }
-
-                        filterForm.setAppVersionTags(appVersionTagsList);
-                    }
-
-                    if (step.getSeverity() != null) {
-                        filterForm.setSeverities(VulnerabilityTrendHelper.getSeverityList(step.getSeverity()));
-                    }
-
-                    if (step.getRule() != null) {
-                        filterForm.setVulnTypes(Collections.singletonList(step.getRule()));
-                    }
-                    VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
-                    if (step.getQueryBy() == Constants.QUERY_BY_START_DATE || step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
-                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm);
-                    } else {
-                        traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, teamServerProfile.getOrgUuid(), null, filterForm);
+                        VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                     }
                 } catch (UnauthorizedException | IOException e) {
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
                     throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
                 }
-
-                if (traces.getCount() > step.getCount()) {
-                    Result buildResult = Result.fromString(teamServerProfile.getVulnerableBuildResult());
-                    VulnerabilityTrendHelper.logMessage(taskListener, "Failed on the condition where " + stepString);
-                    VulnerabilityTrendHelper.logMessage(taskListener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                    if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                        throw new AbortException("Failed on the condition where " + stepString);
-                    } else {
-                        build.setResult(buildResult);
-                        return null;
-                    }
-
-                }
-
-                VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
             }
             return null;
         }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -379,10 +379,11 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     //makeFilterForm
                     TraceFilterForm filterForm = makeFilterFormWithQueryBy();
 
-                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationName(), step.getAgentType(), filterForm, step.getQueryBy());
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm, step.getQueryBy());
 
                     if(securityCheck.getResult() != null) { // jop is defined for app
                         VulnerabilityTrendHelper.logMessage(taskListener,"Warning: A job outcome policy was defined for ["+step.getApplicationId()+"], overriding security controls");
+                        VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
                         if(!securityCheck.getResult()) { //failed a policy
                             try {
                                 Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -4,6 +4,7 @@ import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
+import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.TraceFilter;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -120,6 +121,8 @@ public class VulnerabilityTrendRecorderTest {
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
         given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getName()).willReturn("local");
@@ -129,6 +132,7 @@ public class VulnerabilityTrendRecorderTest {
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
         given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -1,6 +1,7 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
@@ -10,7 +11,6 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import static org.junit.Assert.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -127,11 +128,14 @@ public class VulnerabilityTrendStepTest {
         when(tracesMock.getCount()).thenReturn(11);
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
 
         doReturn("test").when(stepExecution).getBuildName();
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
         given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -135,7 +135,7 @@ public class VulnerabilityTrendStepTest {
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
         given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());


### PR DESCRIPTION
# Depends on
https://bitbucket.org/contrastsecurity/teamserver/branch/CONTRAST-38212-job-outcome-policy
https://bitbucket.org/contrastsecurity/contrast-ui/branch/CONTRAST-38212-job-outcome-policy
https://github.com/Contrast-Security-OSS/contrast-sdk-java/tree/CONTRAST-39400-jop
# Purpose
Implement the use of the security checks so that applications with one or more job outcome policies are verified against those policies instead of the security controls in jenkins.

# Context
We implemented a security check method in the sdk and will use that to make security checks for a certain application, the security check returns a result and if applicable the job outcome policy that the application failed.

# Request
Please review changes

# Summary of changes
* Removed validations that are no longer valid for applications with job outcome policies defined.
* Implemented changes for pipeline step
* Implemented changes for post build step

# Verification done
* Verified job status matches selected job outcome
* Verified applications without job outcome policies will use security controls defined in jenkins
* Verified applications with job outcome policies will ignore security controls defined in jenkins to allow to easier adoption.