### PR TITLE
Fix typo in freestyle job view

### DIFF
--- a/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
+++ b/src/main/resources/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder/config.jelly
@@ -98,7 +98,7 @@
             </f:entry>
         </f:entry>
         <f:entry>
-            <f:checkbox title="Override Vulenrability Security Controls at the Jenkins system level" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
+            <f:checkbox title="Override Vulnerability Security Controls at the Jenkins system level" name="overrideGlobalThresholdConditions" field="overrideGlobalThresholdConditions"/>
         </f:entry>
     </f:section>
     <style>


### PR DESCRIPTION
This fixes a typo in the freestyle job configuration view. We should also update the screenshot in docs since the typo is visible there, too.