### PR TITLE
Contrast 39829 increate job outcome policy enforceability

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -244,7 +244,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
                 }
                 try {
                     if (VulnerabilityTrendHelper.isApplicableEnabledJobOutcomePolicyExist(contrastSDK, profile.getOrgUuid(), appId)) {
-                        return FormValidation.warning("Your Contrast administrator has set a policy for vulnerability thresholds for this application. The Contrast policy overrides Jenkins vulnerability security controls.");
+                        return FormValidation.warning("Your Contrast administrator has set a policy for vulnerability thresholds for this application. The Contrast policy overrides Jenkins vulnerability security controls and 'query vulnerabilities by' selection.");
                     }
                 } catch (IOException | UnauthorizedException e) {
                     return FormValidation.warning("Unable to make connection with Contrast: " + e.getMessage());

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelper.java
@@ -5,7 +5,14 @@ import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.SecurityCheckForm;
 import com.contrastsecurity.http.TraceFilterForm;
-import com.contrastsecurity.models.*;
+import com.contrastsecurity.models.AgentType;
+import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.Applications;
+import com.contrastsecurity.models.JobOutcomePolicy;
+import com.contrastsecurity.models.Rules;
+import com.contrastsecurity.models.SecurityCheck;
+import com.contrastsecurity.models.Trace;
+import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.ProxyConfiguration;
 import hudson.model.Result;
@@ -21,7 +28,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
 
 
 public class VulnerabilityTrendHelper {
@@ -538,22 +549,8 @@ public class VulnerabilityTrendHelper {
         return apps;
     }
 
-    public static SecurityCheck makeSecurityCheck(ContrastSDK sdk, String organizationUuid, String applicationId, TraceFilterForm filterForm, int queryBy) throws IOException, UnauthorizedException {
+    public static SecurityCheck makeSecurityCheck(ContrastSDK sdk, String organizationUuid, String applicationId) throws IOException, UnauthorizedException {
         SecurityCheckForm form = new SecurityCheckForm(applicationId);
-        switch(queryBy) {
-            case Constants.QUERY_BY_START_DATE:
-                form.setStartDate(filterForm.getStartDate().getTime());
-                break;
-            case Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT:
-            case Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT:
-            case Constants.QUERY_BY_PARAMETER:
-                if(!filterForm.getAppVersionTags().contains("")) { //don't set filter if empty string is set to match behavior of local security controls.
-                    form.setAppVersionTags(filterForm.getAppVersionTags());
-                }
-                break;
-            default:
-                //#noFilter
-        }
         return sdk.makeSecurityCheck(organizationUuid, form);
     }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -11,7 +11,11 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -27,7 +31,13 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -230,7 +240,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
 
                 try {
-                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId, filterForm, queryBy);
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
                     String applicationDisplayForConsoleOutput = "";
                     if(MatchBy.APPLICATION_ORIGIN_NAME.equals(matchBy)) {
                         applicationDisplayForConsoleOutput = "[name = " + condition.getApplicationOriginName() + ", agentType = " + condition.getAgentType()+"]";
@@ -239,7 +249,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     }
 
                     if(securityCheck.getResult() != null) {
-                        VulnerabilityTrendHelper.logMessage(listener,"Warning: Vulnerability Security Controls are predetermined for "+applicationDisplayForConsoleOutput+", overriding security controls.");
+                        VulnerabilityTrendHelper.logMessage(listener,"Warning: Vulnerability Security Controls are predetermined for "+applicationDisplayForConsoleOutput+", overriding security controls and 'query vulnerabilities by' selection.");
 
                         if(securityCheck.getResult()) { //failed a policy
                             VulnerabilityTrendHelper.logMessage(listener, "This application did not violate any Job Outcome Policies");

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -369,7 +369,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     //makeFilterForm
                     TraceFilterForm filterForm = makeFilterFormWithQueryBy();
 
-                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId(), filterForm, step.getQueryBy());
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
                     StringBuilder applicationDisplayForConsoleOutputBuilder = new StringBuilder("[");
 
                     if(step.getApplicationName() != null && !step.getApplicationName().isEmpty()) {
@@ -386,8 +386,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     String appicationDisplayForConsoleOutput = applicationDisplayForConsoleOutputBuilder.toString();
 
                     if(securityCheck.getResult() != null) { // jop is defined for app
-                        VulnerabilityTrendHelper.logMessage(taskListener,"Warning: A job outcome policy was defined for "+appicationDisplayForConsoleOutput+", overriding security controls");
-                        VulnerabilityTrendHelper.logMessage(taskListener, "filterForm: " + filterForm);
+                        VulnerabilityTrendHelper.logMessage(taskListener,"Warning: A job outcome policy was defined for "+appicationDisplayForConsoleOutput+", overriding security controls and queryBy parameter");
                         if(securityCheck.getResult()) { //failed a policy
                             VulnerabilityTrendHelper.logMessage(taskListener, "This application has passed all applicable job outcome policy");
                         } else {

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -5,19 +5,21 @@ import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.SecurityCheck;
-import com.contrastsecurity.models.TraceFilter;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.AbortException;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Build;
+import hudson.model.BuildListener;
+import hudson.model.ItemGroup;
+import hudson.model.Result;
 import jenkins.model.Jenkins;
-import org.apache.xerces.impl.xpath.regex.Match;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -31,7 +33,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
@@ -132,7 +135,7 @@ public class VulnerabilityTrendRecorderTest {
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
         given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -21,11 +21,12 @@ import java.io.PrintStream;
 import static org.junit.Assert.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
 
 @RunWith(PowerMockRunner.class)
@@ -135,7 +136,7 @@ public class VulnerabilityTrendStepTest {
 
         given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
         given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class), anyInt())).willReturn(undifinedPolicySecurityCheck);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
         given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());


### PR DESCRIPTION
# Problem

The Job outcome policy needs to be what defines the vulnerability selection.

# Solution

Remove filtering from security check in order to increase the job outcome policy enforce ability.

