### PR TITLE
Int 198 run jobs with jop without defining thresholds

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.StringJoiner;
 
 /**
  * ThresholdCondition class contains the variables and logic to populate the conditions when verifying for vulnerabilities.
@@ -171,6 +172,27 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
         sb.append(".");
 
         return sb.toString();
+    }
+
+    /**
+     * Returns the description of a condition that has been overridden with a job outcome policy.
+     * @return
+     */
+    public String getStringForOverriden() {
+        StringJoiner sj = new StringJoiner(", ");
+        String preString = "[";
+        String postString = "]";
+
+        if(applicationOriginName != null && agentType != null) {
+            sj.add("name='"+applicationOriginName+"'");
+            sj.add("language='"+agentType+"'");
+        }
+
+        if(applicationId != null) {
+            sj.add("applicationId='"+applicationId+"'");
+        }
+
+        return preString + sj.toString() + postString;
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -183,8 +183,11 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
         String preString = "[";
         String postString = "]";
 
-        if(applicationOriginName != null && agentType != null) {
+        if(applicationOriginName != null) {
             sj.add("name='"+applicationOriginName+"'");
+        }
+
+        if(agentType != null) {
             sj.add("language='"+agentType+"'");
         }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -227,8 +227,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 }
             } else {
 
-                TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
-
                 try {
                     SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
                     String applicationDisplayForConsoleOutput = "";
@@ -255,6 +253,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                             }
                         }
                     } else {
+                        TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
                         
                         // if global threshold conditions cannot be overridden or the user does not want to override them
                         if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -229,14 +229,10 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
                 try {
                     SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
-                    String applicationDisplayForConsoleOutput = "";
-                    if(MatchBy.APPLICATION_ORIGIN_NAME.equals(matchBy)) {
-                        applicationDisplayForConsoleOutput = "[name = " + condition.getApplicationOriginName() + ", agentType = " + condition.getAgentType()+"]";
-                    } else {
-                        applicationDisplayForConsoleOutput = "[appId="+appId+"]";
-                    }
 
                     if(securityCheck.getResult() != null) {
+                        String applicationDisplayForConsoleOutput = condition.getStringForOverriden();
+                        VulnerabilityTrendHelper.logMessage(listener, "Checking application " + applicationDisplayForConsoleOutput);
                         VulnerabilityTrendHelper.logMessage(listener,"Your Contrast admin has overridden policies you may have set in Vulnerability Security Controls or the 'query by' parameter");
 
                         if(securityCheck.getResult()) { //failed a policy

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -183,13 +183,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         List<ThresholdCondition> thresholdConditions = conditions;
 
-        // if global threshold conditions cannot be overridden or the user does not want to override them
-        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
-            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
-            if (thresholdConditions.isEmpty()) {
-                throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
-            }
-        }
         // iterate over conditions; fail on first
         for (ThresholdCondition condition : thresholdConditions) {
 
@@ -236,8 +229,6 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
                 TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
 
-
-
                 try {
                     SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
                     String applicationDisplayForConsoleOutput = "";
@@ -264,6 +255,15 @@ public class VulnerabilityTrendRecorder extends Recorder {
                             }
                         }
                     } else {
+                        
+                        // if global threshold conditions cannot be overridden or the user does not want to override them
+                        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
+                            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+                            if (thresholdConditions.isEmpty()) {
+                                throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
+                            }
+                        }
+
                         VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                         VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
                         if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -366,9 +366,6 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                 String stepString = step.buildStepString();
 
                 try {
-                    //makeFilterForm
-                    TraceFilterForm filterForm = makeFilterFormWithQueryBy();
-
                     SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
                     StringBuilder applicationDisplayForConsoleOutputBuilder = new StringBuilder("[");
 
@@ -399,6 +396,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                             }
                         }
                     } else { //regular verify
+
+                        //makeFilterForm
+                        TraceFilterForm filterForm = makeFilterFormWithQueryBy();
 
                         VulnerabilityTrendHelper.logMessage(taskListener, "Checking the step condition where " + stepString);
 

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -4,9 +4,11 @@ import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
+import com.contrastsecurity.models.JobOutcomePolicy;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
+import com.google.common.collect.Lists;
 import hudson.AbortException;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -470,6 +472,122 @@ public class VulnerabilityTrendRecorderTest {
         when(build.getNumber()).thenReturn(buildNumber);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
+    }
+
+    /**
+     * Test that a job configured with an application that has it's thresholds overridden by a job outcome policy does not need to have a threshold configured in jenkins first.
+     */
+    @Test
+    public void testSuccessfulJopWithoutThreshold() throws Exception{
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        final int buildNumber = 1;
+        final String buildParentFullName = "Project";
+
+        //a condition without any thresholds
+        ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
+        when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
+
+        conditions.add(defaultThresholdCondition);
+
+        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.getThresholdConditions(any(), any())).willReturn(Lists.newArrayList());//simulate no global thresholds defined.
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+            "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
+
+        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profileMock = mock(TeamServerProfile.class);
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
+
+        JobOutcomePolicy jobOutcomePolicyMock = mock(JobOutcomePolicy.class);
+        when(jobOutcomePolicyMock.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.UNSTABLE);
+
+        SecurityCheck securityCheckMock = mock(SecurityCheck.class);
+        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString())).thenReturn(securityCheckMock);
+        when(securityCheckMock.getResult()).thenReturn(false);
+        when(securityCheckMock.getJobOutcomePolicy()).thenReturn(jobOutcomePolicyMock);
+
+        when(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any())).thenReturn(Result.UNSTABLE);
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        AbstractProject<?, ?> parent = mock(AbstractProject.class);
+
+        ItemGroup itemGroup = mock(ItemGroup.class);
+        when(itemGroup.getFullName()).thenReturn("");
+        when(parent.getParent()).thenReturn(itemGroup);
+
+        when(parent.getFullName()).thenReturn(buildParentFullName);
+
+        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(buildNumber);
+
+        assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
+    }
+
+    /**
+     * Test that a job configured with an application without any applicable job outcome policies throws an AbortException when no global threshold is defined.
+     */
+    @Test(expected = AbortException.class)
+    public void testFailNonJopWithoutThreshold() throws Exception{
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        final int buildNumber = 1;
+        final String buildParentFullName = "Project";
+
+        //a condition without any thresholds
+        ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
+        when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
+
+        conditions.add(defaultThresholdCondition);
+
+        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.getThresholdConditions(any(), any())).willReturn(Lists.newArrayList());//simulate no global thresholds defined.
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+            "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
+
+        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profileMock = mock(TeamServerProfile.class);
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
+
+        SecurityCheck securityCheckMock = mock(SecurityCheck.class);
+        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString())).thenReturn(securityCheckMock);
+        when(securityCheckMock.getResult()).thenReturn(null);
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        AbstractProject<?, ?> parent = mock(AbstractProject.class);
+
+        ItemGroup itemGroup = mock(ItemGroup.class);
+        when(itemGroup.getFullName()).thenReturn("");
+        when(parent.getParent()).thenReturn(itemGroup);
+
+        when(parent.getFullName()).thenReturn(buildParentFullName);
+
+        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(buildNumber);
+
+        vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }
 
 }


### PR DESCRIPTION
# Purpose
Allow jobs with application who's thresholds are overridden by a job outcome policy to run without having to define a local or global thresholds first. This way the user can start using the plugin in minimal configuration.

# Steps to reproduce
1. Go to manage settings and delete all thresholds.
1. Run a job with an application that has an applicable job outcome policy
1. Run the job.

# Expected
1. Jobs with applications that have applicable job outcome policies will run as expected.
1. Jobs with applications that do not have applicable job outcome policies will fail with warning that there are no thresholds defined.

# Other
- Removed the queryBy filter warnings for applications with job outcome policies since it is going to be overridden by the job outcome policy
- Added a description for when applications with job outcome policies are checked so that it is easier to read the log output when multiple applications are configured for the same job