### PR TITLE
removed version number in readme. Updating the version number in the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--Jenkins Cat -->
 ![Jenkins Cat](img/jenkins-cat.png "Jenkins Cat" )
 
-# Contrast Jenkins Plugin - Version 3.3
+# Contrast Jenkins Plugin
 
 Repository for the Contrast Jenkins plugin. This plugin adds the ability to configure a connection to a Jenkins Build.
 


### PR DESCRIPTION
# Purpose
Remove the version number in the readme

# Context
It is not part of the automated release process, provides little value, and can cause confusion of the difference between the released version vs. the snapshot version. The version number can be more easily and reliably be seen in the release tags.