### PR TITLE
INT 205 jenkins add invalid connection error

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -185,129 +185,127 @@ public class VulnerabilityTrendRecorder extends Recorder {
             String errorMessage = String.format("Connection to Teamserver failed with response: " + connection.getResponseCode());
             throw new AbortException(errorMessage);
         }
-        else {
-            boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
 
-            List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
+        boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
 
-            List<ThresholdCondition> thresholdConditions = conditions;
+        List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
 
-            // iterate over conditions; fail on first
-            for (ThresholdCondition condition : thresholdConditions) {
+        List<ThresholdCondition> thresholdConditions = conditions;
+
+        // iterate over conditions; fail on first
+        for (ThresholdCondition condition : thresholdConditions) {
 
 
-                String appId = condition.getApplicationId();
-                MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
-                switch(matchBy){
-                    case APPLICATION_ORIGIN_NAME:
-                        try {
-                            Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
-
-                            if (app == null) {
-                                String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", condition.getApplicationOriginName(), condition.getAgentType());
-                                if (profile.isFailOnWrongApplicationId() || condition.isFailOnAppNotFound()) {
-                                    throw new AbortException(errorMessage);
-                                } else {
-                                    VulnerabilityTrendHelper.logMessage(listener, errorMessage);
-                                }
-                            } else {
-                                condition.setApplicationId(app.getId());
-                                appId = condition.getApplicationId();
-                                VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
-                            }
-                        } catch (UnauthorizedException e) {
-                            VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                            throw new AbortException("Unable to retrieve application information from TeamServer.");
-                        }
-                        break;
-                    case APPLICATION_ID:
-                    default:
-                        if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
-                            appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
-                        }
-                        break;
-                }
-
-                boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
-                if (!applicationIdExists) {
-                    VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + appId + "' not found.");
-                    if (profile.isFailOnWrongApplicationId()) {
-                        throw new AbortException("Application with ID '" + appId + "' not found.");
-                    }
-                } else {
-
+            String appId = condition.getApplicationId();
+            MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
+            switch(matchBy){
+                case APPLICATION_ORIGIN_NAME:
                     try {
-                        SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
+                        Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
 
-                        if(securityCheck.getResult() != null) {
-                            String applicationDisplayForConsoleOutput = condition.getStringForOverriden();
-                            VulnerabilityTrendHelper.logMessage(listener, "Checking application " + applicationDisplayForConsoleOutput);
-                            VulnerabilityTrendHelper.logMessage(listener,"Your Contrast admin has overridden policies you may have set in Vulnerability Security Controls or the 'query by' parameter");
-
-                            if(securityCheck.getResult()) { //failed a policy
-                                VulnerabilityTrendHelper.logMessage(listener, "This application did not violate any Contrast policies");
-                                return true;
+                        if (app == null) {
+                            String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", condition.getApplicationOriginName(), condition.getAgentType());
+                            if (profile.isFailOnWrongApplicationId() || condition.isFailOnAppNotFound()) {
+                                throw new AbortException(errorMessage);
                             } else {
-                                try {
-                                    Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
-                                    VulnerabilityTrendHelper.logMessage(listener,"This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
-                                    build.setResult(jobResult);
-                                    return true;
-                                } catch (VulnerabilityTrendHelperException e) {
-                                    throw new AbortException(e.getMessage());
-                                }
+                                VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                             }
                         } else {
-                            TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
-
-                            // if global threshold conditions cannot be overridden or the user does not want to override them
-                            if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
-                                thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
-                                if (thresholdConditions.isEmpty()) {
-                                    throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
-                                }
-                            }
-
-                            VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
-                            VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
-                            if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
-                                traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
-                            } else {
-                                traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
-                            }
-                            resultTraces.addAll(traces.getTraces());
-                            int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
-
-                            if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
-                                // save results before failing build
-                                buildResult(resultTraces, build);
-
-                                Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
-                                VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
-                                VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                                if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                                    throw new AbortException("Failed on the threshold condition where " + condition.toString());
-                                } else {
-                                    build.setResult(buildResult);
-                                    return true;
-                                }
-                            }
+                            condition.setApplicationId(app.getId());
+                            appId = condition.getApplicationId();
+                            VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
                         }
                     } catch (UnauthorizedException e) {
                         VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                        throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
+                        throw new AbortException("Unable to retrieve application information from TeamServer.");
                     }
-                }
+                    break;
+                case APPLICATION_ID:
+                default:
+                    if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
+                        appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
+                    }
+                    break;
             }
 
+            boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
+            if (!applicationIdExists) {
+                VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + appId + "' not found.");
+                if (profile.isFailOnWrongApplicationId()) {
+                    throw new AbortException("Application with ID '" + appId + "' not found.");
+                }
+            } else {
 
-            buildResult(resultTraces, build);
+                try {
+                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
 
-            VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
+                    if(securityCheck.getResult() != null) {
+                        String applicationDisplayForConsoleOutput = condition.getStringForOverriden();
+                        VulnerabilityTrendHelper.logMessage(listener, "Checking application " + applicationDisplayForConsoleOutput);
+                        VulnerabilityTrendHelper.logMessage(listener,"Your Contrast admin has overridden policies you may have set in Vulnerability Security Controls or the 'query by' parameter");
 
-            return true;
+                        if(securityCheck.getResult()) { //failed a policy
+                            VulnerabilityTrendHelper.logMessage(listener, "This application did not violate any Contrast policies");
+                            return true;
+                        } else {
+                            try {
+                                Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
+                                VulnerabilityTrendHelper.logMessage(listener,"This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
+                                build.setResult(jobResult);
+                                return true;
+                            } catch (VulnerabilityTrendHelperException e) {
+                                throw new AbortException(e.getMessage());
+                            }
+                        }
+                    } else {
+                        TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
 
+                        // if global threshold conditions cannot be overridden or the user does not want to override them
+                        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
+                            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+                            if (thresholdConditions.isEmpty()) {
+                                throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
+                            }
+                        }
+
+                        VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
+                        VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
+                        if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
+                        } else {
+                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
+                        }
+                        resultTraces.addAll(traces.getTraces());
+                        int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
+
+                        if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
+                            // save results before failing build
+                            buildResult(resultTraces, build);
+
+                            Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
+                            VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
+                            VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                            if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                                throw new AbortException("Failed on the threshold condition where " + condition.toString());
+                            } else {
+                                build.setResult(buildResult);
+                                return true;
+                            }
+                        }
+                    }
+                } catch (UnauthorizedException e) {
+                    VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+                    throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
+                }
+            }
         }
+
+
+        buildResult(resultTraces, build);
+
+        VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
+
+        return true;
 
     }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -180,17 +180,14 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
 
-
         try {
             final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
             if (organizations == null || organizations.getOrganization() == null) {
-                String orgErrorMessage = String.format("Connection error: No organization found, Check your credentials and URL.");
-                throw new AbortException(orgErrorMessage);
+               throw new AbortException("Connection error: No organization found, Check your credentials and URL.");
             }
 
         } catch (UnauthorizedException | IOException e) {
-            String connectionErrorMessage = String.format("Unable to connect to Contrast.");
-            throw new AbortException(connectionErrorMessage);
+            throw new AbortException("Unable to connect to Contrast.");
         }
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -31,6 +31,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -177,131 +178,139 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
 
-        boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
 
-        List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
+        final HttpURLConnection connection = contrastSDK.makeConnection(profile.getTeamServerUrl(), "GET");
 
-        List<ThresholdCondition> thresholdConditions = conditions;
-
-        // if global threshold conditions cannot be overridden or the user does not want to override them
-        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
-            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
-            if (thresholdConditions.isEmpty()) {
-                throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
-            }
+        if(connection.getResponseCode() != HttpURLConnection.HTTP_OK){
+            String errorMessage = String.format("Connection to Teamserver failed with response: " + connection.getResponseCode());
+            throw new AbortException(errorMessage);
         }
-        // iterate over conditions; fail on first
-        for (ThresholdCondition condition : thresholdConditions) {
+        else {
+            boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
 
+            List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
 
-            String appId = condition.getApplicationId();
-            MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
-            switch(matchBy){
-                case APPLICATION_ORIGIN_NAME:
-                    try {
-                        Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
+            List<ThresholdCondition> thresholdConditions = conditions;
 
-                        if (app == null) {
-                            String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", condition.getApplicationOriginName(), condition.getAgentType());
-                            if (profile.isFailOnWrongApplicationId() || condition.isFailOnAppNotFound()) {
-                                throw new AbortException(errorMessage);
+            // if global threshold conditions cannot be overridden or the user does not want to override them
+            if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
+                thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+                if (thresholdConditions.isEmpty()) {
+                    throw new AbortException("Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.");
+                }
+            }
+            // iterate over conditions; fail on first
+            for (ThresholdCondition condition : thresholdConditions) {
+
+                String appId = condition.getApplicationId();
+                MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
+                switch(matchBy){
+                    case APPLICATION_ORIGIN_NAME:
+                        try {
+                            Application app = contrastSDK.getApplicationByNameAndLanguage(profile.getOrgUuid(), condition.getApplicationOriginName(), VulnerabilityTrendHelper.getAgentTypeFromString(condition.getAgentType()));
+
+                            if (app == null) {
+                                String errorMessage = String.format("Application with [name = %s, agentType = %s] not found.", condition.getApplicationOriginName(), condition.getAgentType());
+                                if (profile.isFailOnWrongApplicationId() || condition.isFailOnAppNotFound()) {
+                                    throw new AbortException(errorMessage);
+                                } else {
+                                    VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+                                }
                             } else {
-                                VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+                                condition.setApplicationId(app.getId());
+                                appId = condition.getApplicationId();
+                                VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
+                            }
+                        } catch (UnauthorizedException e) {
+                            VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+                            throw new AbortException("Unable to retrieve application information from TeamServer.");
+                        }
+                        break;
+                    case APPLICATION_ID:
+                    default:
+                        if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
+                            appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
+                        }
+                        break;
+                }
+
+                boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
+                if (!applicationIdExists) {
+                    VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + appId + "' not found.");
+                    if (profile.isFailOnWrongApplicationId()) {
+                        throw new AbortException("Application with ID '" + appId + "' not found.");
+                    }
+                } else {
+
+                    TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
+
+                    try {
+                        SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
+                        String applicationDisplayForConsoleOutput = "";
+                        if(MatchBy.APPLICATION_ORIGIN_NAME.equals(matchBy)) {
+                            applicationDisplayForConsoleOutput = "[name = " + condition.getApplicationOriginName() + ", agentType = " + condition.getAgentType()+"]";
+                        } else {
+                            applicationDisplayForConsoleOutput = "[appId="+appId+"]";
+                        }
+
+                        if(securityCheck.getResult() != null) {
+                            VulnerabilityTrendHelper.logMessage(listener,"Your Contrast admin has overridden policies you may have set in Vulnerability Security Controls or the 'query by' parameter");
+
+                            if(securityCheck.getResult()) { //failed a policy
+                                VulnerabilityTrendHelper.logMessage(listener, "This application did not violate any Contrast policies");
+                                return true;
+                            } else {
+                                try {
+                                    Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
+                                    VulnerabilityTrendHelper.logMessage(listener,"This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
+                                    build.setResult(jobResult);
+                                    return true;
+                                } catch (VulnerabilityTrendHelperException e) {
+                                    throw new AbortException(e.getMessage());
+                                }
                             }
                         } else {
-                            condition.setApplicationId(app.getId());
-                            appId = condition.getApplicationId();
-                            VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
+                            VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
+                            VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
+                            if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
+                                traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
+                            } else {
+                                traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
+                            }
+                            resultTraces.addAll(traces.getTraces());
+                            int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
+
+                            if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
+                                // save results before failing build
+                                buildResult(resultTraces, build);
+
+                                Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
+                                VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
+                                VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
+                                if (buildResult.toString().equals(Result.FAILURE.toString())) {
+                                    throw new AbortException("Failed on the threshold condition where " + condition.toString());
+                                } else {
+                                    build.setResult(buildResult);
+                                    return true;
+                                }
+                            }
                         }
                     } catch (UnauthorizedException e) {
                         VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                        throw new AbortException("Unable to retrieve application information from TeamServer.");
+                        throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
                     }
-                    break;
-                case APPLICATION_ID:
-                default:
-                    if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
-                        appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
-                    }
-                    break;
-            }
-
-            boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
-            if (!applicationIdExists) {
-                VulnerabilityTrendHelper.logMessage(listener, "Application with ID '" + appId + "' not found.");
-                if (profile.isFailOnWrongApplicationId()) {
-                    throw new AbortException("Application with ID '" + appId + "' not found.");
-                }
-            } else {
-
-                TraceFilterForm filterForm = buildFilterFormForCondition(condition, build, appId, listener);
-
-
-
-                try {
-                    SecurityCheck securityCheck = VulnerabilityTrendHelper.makeSecurityCheck(contrastSDK, profile.getOrgUuid(), appId);
-                    String applicationDisplayForConsoleOutput = "";
-                    if(MatchBy.APPLICATION_ORIGIN_NAME.equals(matchBy)) {
-                        applicationDisplayForConsoleOutput = "[name = " + condition.getApplicationOriginName() + ", agentType = " + condition.getAgentType()+"]";
-                    } else {
-                        applicationDisplayForConsoleOutput = "[appId="+appId+"]";
-                    }
-
-                    if(securityCheck.getResult() != null) {
-                        VulnerabilityTrendHelper.logMessage(listener,"Your Contrast admin has overridden policies you may have set in Vulnerability Security Controls or the 'query by' parameter");
-
-                        if(securityCheck.getResult()) { //failed a policy
-                            VulnerabilityTrendHelper.logMessage(listener, "This application did not violate any Contrast policies");
-                            return true;
-                        } else {
-                            try {
-                                Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
-                                VulnerabilityTrendHelper.logMessage(listener,"This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
-                                build.setResult(jobResult);
-                                return true;
-                            } catch (VulnerabilityTrendHelperException e) {
-                                throw new AbortException(e.getMessage());
-                            }
-                        }
-                    } else {
-                        VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
-                        VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
-                        if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
-                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), appId, filterForm);
-                        } else {
-                            traces = VulnerabilityTrendHelper.getAllTraces(contrastSDK, profile.getOrgUuid(), null, filterForm);
-                        }
-                        resultTraces.addAll(traces.getTraces());
-                        int thresholdCount = condition.getThresholdCount(); // Integer.parseInt(condition.getThresholdCount());
-
-                        if (traces.getCount() > thresholdCount && !ignoreContrastFindings) {
-                            // save results before failing build
-                            buildResult(resultTraces, build);
-
-                            Result buildResult = Result.fromString(profile.getVulnerableBuildResult());
-                            VulnerabilityTrendHelper.logMessage(listener, "Failed on the threshold condition where " + condition.toString());
-                            VulnerabilityTrendHelper.logMessage(listener, VulnerabilityTrendHelper.getVulnerabilityInfoString(traces));
-                            if (buildResult.toString().equals(Result.FAILURE.toString())) {
-                                throw new AbortException("Failed on the threshold condition where " + condition.toString());
-                            } else {
-                                build.setResult(buildResult);
-                                return true;
-                            }
-                        }
-                    }
-                } catch (UnauthorizedException e) {
-                    VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                    throw new AbortException("Unable to retrieve vulnerability information from TeamServer.");
                 }
             }
+
+
+            buildResult(resultTraces, build);
+
+            VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
+
+            return true;
+
         }
 
-
-        buildResult(resultTraces, build);
-
-        VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
-
-        return true;
     }
 
     @Override

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
@@ -20,6 +21,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import lombok.Getter;
@@ -179,11 +181,16 @@ public class VulnerabilityTrendRecorder extends Recorder {
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
 
 
-        final HttpURLConnection connection = contrastSDK.makeConnection(profile.getTeamServerUrl(), "GET");
+        try {
+            final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
+            if (organizations == null || organizations.getOrganization() == null) {
+                String orgErrorMessage = String.format("Connection error: No organization found, Check your credentials and URL.");
+                throw new AbortException(orgErrorMessage);
+            }
 
-        if(connection.getResponseCode() != HttpURLConnection.HTTP_OK){
-            String errorMessage = String.format("Connection to Teamserver failed with response: " + connection.getResponseCode());
-            throw new AbortException(errorMessage);
+        } catch (UnauthorizedException | IOException e) {
+            String connectionErrorMessage = String.format("Unable to connect to Contrast.");
+            throw new AbortException(connectionErrorMessage);
         }
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -187,7 +187,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
             }
 
         } catch (UnauthorizedException | IOException e) {
-            throw new AbortException("Unable to connect to Contrast.");
+            String connectionError = String.format("Unable to connect to Contrast. %s", e.getMessage());
+            throw new AbortException(connectionError);
         }
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -187,8 +187,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
             }
 
         } catch (UnauthorizedException | IOException e) {
-            String connectionError = String.format("Unable to connect to Contrast. %s", e.getMessage());
-            throw new AbortException(connectionError);
+            VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+            throw new AbortException("Unable to connect to Contrast.");
         }
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -3,6 +3,7 @@ package com.aspectsecurity.contrast.contrastjenkins;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Application;
+import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -317,6 +318,17 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
+
+            try {
+                final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
+                if (organizations == null || organizations.getOrganization() == null) {
+                    throw new AbortException("Connection error: No organization found, Check your credentials and URL.");
+                }
+
+            } catch (UnauthorizedException | IOException e) {
+                VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
+                throw new AbortException("Unable to connect to Contrast.");
+            }
 
             //Convert app name and agent type to app id
             if(step.getApplicationId() == null && step.getApplicationName() != null && step.getAgentType() != null) {

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -28,6 +28,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -100,6 +101,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
@@ -152,6 +157,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }
 
@@ -198,6 +207,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
@@ -243,6 +256,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
@@ -284,6 +301,10 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
+
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
 
@@ -338,6 +359,10 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
+
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -401,6 +426,10 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
+
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -468,6 +497,10 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
+
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -5,6 +5,8 @@ import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.JobOutcomePolicy;
+import com.contrastsecurity.models.Organization;
+import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -30,7 +32,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,9 +104,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -159,9 +161,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }
@@ -209,9 +212,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -258,9 +262,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -304,9 +309,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
 
@@ -362,9 +368,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -429,9 +436,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(1);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -500,9 +508,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profile.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -565,9 +574,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profileMock.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -624,9 +634,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
 
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getResponseCode()).thenReturn(200);
-        given(contrastSDKMock.makeConnection(profileMock.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -565,6 +565,10 @@ public class VulnerabilityTrendRecorderTest {
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
 
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profileMock.getTeamServerUrl(), "GET")).willReturn(mockConnection);
+
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
@@ -619,6 +623,10 @@ public class VulnerabilityTrendRecorderTest {
 
         when(build.isBuilding()).thenReturn(true);
         when(build.getNumber()).thenReturn(buildNumber);
+
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(200);
+        given(contrastSDKMock.makeConnection(profileMock.getTeamServerUrl(), "GET")).willReturn(mockConnection);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -1,6 +1,8 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.Organization;
+import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -78,6 +80,11 @@ public class VulnerabilityTrendStepTest {
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
 
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
         assertNull(stepExecution.run());
@@ -107,6 +114,11 @@ public class VulnerabilityTrendStepTest {
         TeamServerProfile profile = mock(TeamServerProfile.class);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 


### PR DESCRIPTION
**Ticket:**
https://contrast.atlassian.net/browse/INT-205

**Ticket Summary:**
When running a job with an application that has a jop, but the connection to teamserver is severed, the feedback in the console it "application {appid} not found"

**Steps to reproduce**
1. Configure a job with an application that has a job outcome policy
2. Run the job (should get expected outcome)
3. Turn off teamserver
4. Re-run the job 

**Changes**
Added a make connection test to check for a good response from teamserver before performing a security check with feedback of a connection issue and a response code. Also added it to the mocks for tests to run.

**Note**
You can ignore the diff in the single file VulnerabilityTrendRecorder.java beyond:  
(It's because of the indent when wrapping it in the else)

```
if(connection.getResponseCode() != HttpURLConnection.HTTP_OK){
            String errorMessage = String.format("Connection to Teamserver failed with response: " + connection.getResponseCode());
            throw new AbortException(errorMessage);
        }
else {
```