### PR TITLE
INT-398 Throw AbortExceptoin on failure so that the rest of the build doesn't…

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -470,7 +470,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         }
                         VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                     }
-                } catch (UnauthorizedException | IOException e) {
+                } catch (AbortException e) { //Fail Fast when Failure is selected for a vulnerable build
+                    throw e;
+                }catch (UnauthorizedException | IOException e) {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve vulnerability information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
+import hudson.AbortException;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -164,4 +165,51 @@ public class VulnerabilityTrendStepTest {
         assertNull(stepExecution.run());
         verify(stepExecution.build).setResult(Result.fromString(profile.getVulnerableBuildResult()));
     }
+
+
+    @Test(expected = AbortException.class)
+    public void testVulnerableBuildWithFailureSelectedAndUnchecked() throws Exception {
+        VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+        stepExecution.build = mock(Run.class);
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.taskListener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(11);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+
+
+        doReturn("test").when(stepExecution).getBuildName();
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
+
+        stepExecution.run();
+    }
+
 }


### PR DESCRIPTION
# Steps to reproduce
1. Create a pipeline with a vulnerable application with count=0
2. In the system config, select FAILURE as the vulnerable build outcome
3. In the system config, uncheck the "apply..."
4. Run the pipeline