### PR TITLE
INT-399, INT-398, INT-346 fail fast

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -166,13 +166,18 @@ public class VulnerabilityTrendRecorder extends Recorder {
      * Set the build result based on contrast configuration
      * @param build build object
      * @param profile teamserver profile
+     * @param message Message to log when status is failure
      * @return true = the result was set, false = the result was not set
      */
-    private boolean updateBuildResult(AbstractBuild<?, ?> build, TeamServerProfile profile) {
+    private boolean updateBuildResult(AbstractBuild<?, ?> build, TeamServerProfile profile, String message) throws AbortException {
         if(profile.isApplyVulnerableBuildResultOnContrastError()) {
             Result profileVulnerableBuildResult = Result.fromString(profile.getVulnerableBuildResult());
-            build.setResult(profileVulnerableBuildResult);
-            return true;
+            if(Result.FAILURE.equals(profileVulnerableBuildResult)) {
+                throw new AbortException(message);
+            } else {
+                build.setResult(profileVulnerableBuildResult);
+                return true;
+            }
         }
         return false;
     }
@@ -197,15 +202,17 @@ public class VulnerabilityTrendRecorder extends Recorder {
         try {
             final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
             if (organizations == null || organizations.getOrganization() == null) {
-                VulnerabilityTrendHelper.logMessage(listener, CONTRAST_ERROR_PREFIX + "No organization found, Check your credentials and URL.");
-                updateBuildResult(build, profile);
+                String errorMessage = CONTRAST_ERROR_PREFIX + "No organization found, Check your credentials and URL.";
+                VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+                updateBuildResult(build, profile, errorMessage);
                 return true;
             }
 
         } catch (UnauthorizedException | IOException e) {
-            VulnerabilityTrendHelper.logMessage(listener, CONTRAST_ERROR_PREFIX + "Unable to connect to Contrast.");
+            String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to connect to Contrast.";
+            VulnerabilityTrendHelper.logMessage(listener, errorMessage);
             VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-            updateBuildResult(build, profile);
+            updateBuildResult(build, profile, errorMessage);
             return true;
         }
 
@@ -234,7 +241,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                                 throw new AbortException(errorMessage);
                             }
 
-                            if(updateBuildResult(build, profile)) {
+                            if(updateBuildResult(build, profile, errorMessage)) {
                                 return true;
                             } else {
                                 continue;
@@ -248,7 +255,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve application information from TeamServer.";
                         VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                         VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                        if(updateBuildResult(build, profile)) {
+                        if(updateBuildResult(build, profile, errorMessage)) {
                             return true;
                         } else {
                             continue;
@@ -265,8 +272,9 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
             if (!applicationIdExists) {
+                String errorMessage = CONTRAST_ERROR_PREFIX + "Application with ID '" + appId + "' not found.";
                 VulnerabilityTrendHelper.logMessage(listener, CONTRAST_ERROR_PREFIX + "Application with ID '" + appId + "' not found.");
-                if(updateBuildResult(build, profile)) {
+                if(updateBuildResult(build, profile, errorMessage)) {
                     return true;
                 } else {
                     continue;
@@ -299,7 +307,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve outcome from job outcome policy";
                                 VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                                if(updateBuildResult(build, profile)) {
+                                if(updateBuildResult(build, profile, errorMessage)) {
                                     return true;
                                 } else {
                                     continue;
@@ -315,7 +323,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                             if (thresholdConditions.isEmpty()) {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.";
                                 VulnerabilityTrendHelper.logMessage(listener, errorMessage);
-                                if(updateBuildResult(build, profile)) {
+                                if(updateBuildResult(build, profile, errorMessage)) {
                                     return true;
                                 } else {
                                     continue;
@@ -352,7 +360,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve vulnerability information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                    if(updateBuildResult(build, profile)) {
+                    if(updateBuildResult(build, profile, errorMessage)) {
                         return true;
                     } else {
                         continue;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -287,9 +287,14 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         } else {
                             try {
                                 Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
-                                VulnerabilityTrendHelper.logMessage(listener,"This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
-                                build.setResult(jobResult);
-                                return true;
+                                String message = "This application "+applicationDisplayForConsoleOutput+" violated the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'";
+                                VulnerabilityTrendHelper.logMessage(listener,message);
+                                if(Result.FAILURE.equals(jobResult)) {
+                                    throw new AbortException(message);
+                                } else {
+                                    build.setResult(jobResult);
+                                    return true;
+                                }
                             } catch (VulnerabilityTrendHelperException e) {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve outcome from job outcome policy";
                                 VulnerabilityTrendHelper.logMessage(listener, errorMessage);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -34,6 +34,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -115,7 +116,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
 
             filterForm.setAppVersionTags(appVersionTagsList);
         } else if (queryBy == Constants.QUERY_BY_START_DATE) {
-            filterForm.setStartDate(build.getTime());
+            filterForm.setStartDate(new Date(build.getStartTimeInMillis()));
         } else if (queryBy == Constants.QUERY_BY_PARAMETER) {
             final EnvVars env = build.getEnvironment(listener);
             String appVersionTag;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -421,9 +421,15 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         } else {
                             try {
                                 Result jobResult = VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(securityCheck.getJobOutcomePolicy().getOutcome());
-                                VulnerabilityTrendHelper.logMessage(taskListener,"This application "+appicationDisplayForConsoleOutput+" has failed the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'");
+                                String message = "This application "+appicationDisplayForConsoleOutput+" has failed the Contrast policy '"+securityCheck.getJobOutcomePolicy().getName()+"'";
+                                VulnerabilityTrendHelper.logMessage(taskListener,message);
                                 VulnerabilityTrendHelper.logMessage(taskListener, "Setting build result to : " + jobResult);
-                                build.setResult(jobResult);
+                                if(Result.FAILURE.equals(jobResult)) {
+                                    throw new AbortException(message);
+                                } else {
+                                    build.setResult(jobResult);
+                                    return null;
+                                }
                             } catch (VulnerabilityTrendHelperException e) {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve outcome from job outcome policy";
                                 VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -310,13 +310,18 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         /**
          * Set the build result based on contrast configuration
          * @param profile teamserver profile
+         * @parma message Message to log when result is failure
          * @return true = the result was set, false = the result was not set
          */
-        private boolean updateBuildResult(TeamServerProfile profile) {
+        private boolean updateBuildResult(TeamServerProfile profile, String message) throws AbortException {
             if(profile.isApplyVulnerableBuildResultOnContrastError()) {
                 Result profileVulnerableBuildResult = Result.fromString(profile.getVulnerableBuildResult());
                 VulnerabilityTrendHelper.logMessage(taskListener, "Setting build result to : "+profileVulnerableBuildResult.toString());
-                build.setResult(profileVulnerableBuildResult);
+                if(Result.FAILURE.equals(profileVulnerableBuildResult)) {
+                    throw new AbortException(message);
+                } else {
+                    build.setResult(profileVulnerableBuildResult);
+                }
                 return true;
             }
             return false;
@@ -338,15 +343,17 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             try {
                 final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
                 if (organizations == null || organizations.getOrganization() == null) {
-                    VulnerabilityTrendHelper.logMessage(taskListener, CONTRAST_ERROR_PREFIX + "No organization found, Check your credentials and URL.");
-                    updateBuildResult(teamServerProfile);
+                    String errorMessage = CONTRAST_ERROR_PREFIX + "No organization found, Check your credentials and URL.";
+                    VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
+                    updateBuildResult(teamServerProfile, errorMessage);
                     return null;
                 }
 
             } catch (UnauthorizedException | IOException e) {
-                VulnerabilityTrendHelper.logMessage(taskListener, CONTRAST_ERROR_PREFIX + "Unable to connect to Contrast.");
+                String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to connect to Contrast.";
+                VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                 VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                updateBuildResult(teamServerProfile);
+                updateBuildResult(teamServerProfile, errorMessage);
                 return null;
             }
 
@@ -360,7 +367,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     if(app == null) {
                         String errorMessage = String.format(CONTRAST_ERROR_PREFIX + "Application with [name = %s, agentType = %s] not found.", step.getApplicationName(), step.getAgentType());
                         VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
-                        updateBuildResult(teamServerProfile);
+                        updateBuildResult(teamServerProfile, errorMessage);
                         return null;
                     } else {
                         step.setApplicationId(app.getId());
@@ -370,7 +377,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                    updateBuildResult(teamServerProfile);
+                    updateBuildResult(teamServerProfile, errorMessage);
                     return null;
                 }
             }
@@ -389,8 +396,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
             //validation
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, teamServerProfile.getOrgUuid(), step.getApplicationId());
             if (!applicationIdExists) {
-                VulnerabilityTrendHelper.logMessage(taskListener, CONTRAST_ERROR_PREFIX + "Application with ID '" + step.getApplicationId() + "' not found.");
-                updateBuildResult(teamServerProfile);
+                String errorMessage = CONTRAST_ERROR_PREFIX + "Application with ID '" + step.getApplicationId() + "' not found.";
+                VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
+                updateBuildResult(teamServerProfile, errorMessage);
                 return null;
             } else {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Checking the number of vulnerabilities for " + step.getApplicationId());
@@ -434,7 +442,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve outcome from job outcome policy";
                                 VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                                 VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                                updateBuildResult(teamServerProfile);
+                                updateBuildResult(teamServerProfile, errorMessage);
                                 return null;
                             }
                         }
@@ -482,7 +490,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve vulnerability information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());
-                    updateBuildResult(teamServerProfile);
+                    updateBuildResult(teamServerProfile, errorMessage);
                     return null;
                 }
             }

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -29,6 +29,7 @@ import org.kohsuke.stapler.QueryParameter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -269,7 +270,7 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
 
                 filterForm.setAppVersionTags(appVersionTagsList);
             } else if (step.getQueryBy() == Constants.QUERY_BY_START_DATE) {
-                filterForm.setStartDate(build.getTime());
+                filterForm.setStartDate(new Date(build.getStartTimeInMillis()));
             } else if (step.getQueryBy() == Constants.QUERY_BY_PARAMETER) {
                 final EnvVars env = build.getEnvironment(taskListener);
                 String appVersionTag;

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -470,7 +470,9 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
                         }
                         VulnerabilityTrendHelper.logMessage(taskListener, "This step has passed successfully");
                     }
-                } catch (UnauthorizedException | IOException e) {
+                } catch (AbortException e) { //Fail Fast when Failure is selected for a vulnerable build
+                    throw e;
+                }catch (UnauthorizedException | IOException e) {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve vulnerability information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(taskListener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(taskListener, e.getMessage());

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -1,6 +1,8 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
+import com.contrastsecurity.models.JobOutcomePolicy;
 import com.contrastsecurity.models.Organization;
 import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
@@ -19,6 +21,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.io.PrintStream;
 
 import static org.junit.Assert.assertNull;
@@ -143,9 +146,15 @@ public class VulnerabilityTrendStepTest {
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(11);
 
+
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
         SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
         given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
 
         doReturn("test").when(stepExecution).getBuildName();
 
@@ -154,7 +163,7 @@ public class VulnerabilityTrendStepTest {
         given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.getVulnerableBuildResult()).willReturn(Result.UNSTABLE.toString());
         given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(true);
 
         given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
@@ -166,9 +175,62 @@ public class VulnerabilityTrendStepTest {
         verify(stepExecution.build).setResult(Result.fromString(profile.getVulnerableBuildResult()));
     }
 
+    @Test
+    public void testUnsuccessfulBuildJop() throws Exception {
+        VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+        stepExecution.build = mock(Run.class);
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.taskListener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(11);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
+        JobOutcomePolicy jobOutcomePolicy = mock(JobOutcomePolicy.class);
+        when(jobOutcomePolicy.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.UNSTABLE);
+
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        when(undifinedPolicySecurityCheck.getResult()).thenReturn(false);
+        when(undifinedPolicySecurityCheck.getJobOutcomePolicy()).thenReturn(jobOutcomePolicy);
+
+
+
+        doReturn("test").when(stepExecution).getBuildName();
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
+        given(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class))).willReturn(Result.UNSTABLE);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.UNSTABLE.toString());
+        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
+
+        assertNull(stepExecution.run());
+        verify(stepExecution.build).setResult(Result.fromString(profile.getVulnerableBuildResult()));
+
+    }
+
 
     @Test(expected = AbortException.class)
-    public void testVulnerableBuildWithFailureSelectedAndUnchecked() throws Exception {
+    public void testVulnerableBuildFailureSelected() throws Exception {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
         stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
         stepExecution.build = mock(Run.class);
@@ -211,5 +273,57 @@ public class VulnerabilityTrendStepTest {
 
         stepExecution.run();
     }
+
+    @Test(expected = AbortException.class)
+    public void testVulnerableBuildFailureSelectedJOP() throws Exception {
+        VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+        stepExecution.build = mock(Run.class);
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.taskListener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(11);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
+        JobOutcomePolicy jobOutcomePolicy = mock(JobOutcomePolicy.class);
+        when(jobOutcomePolicy.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.FAIL);
+
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        when(undifinedPolicySecurityCheck.getResult()).thenReturn(false);
+        when(undifinedPolicySecurityCheck.getJobOutcomePolicy()).thenReturn(jobOutcomePolicy);
+
+
+
+        doReturn("test").when(stepExecution).getBuildName();
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
+        given(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class))).willReturn(Result.FAILURE);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
+
+        stepExecution.run();
+    }
+
 
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.models.SecurityCheck;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
+import hudson.AbortException;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -164,4 +165,51 @@ public class VulnerabilityTrendStepTest {
         assertNull(stepExecution.run());
         verify(stepExecution.build).setResult(Result.fromString(profile.getVulnerableBuildResult()));
     }
+
+
+    @Test(expected = AbortException.class)
+    public void testVulnerableBuildWithFailureSelectedAndUnchecked() throws Exception {
+        VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
+        stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
+        stepExecution.build = mock(Run.class);
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.taskListener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        Traces tracesMock = mock(Traces.class);
+        when(tracesMock.getCount()).thenReturn(11);
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
+        SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
+        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+
+
+        doReturn("test").when(stepExecution).getBuildName();
+
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString())).willReturn(undifinedPolicySecurityCheck);
+
+        TeamServerProfile profile = mock(TeamServerProfile.class);
+        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+
+        when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
+
+        stepExecution.run();
+    }
+
 }


### PR DESCRIPTION
# Summary of changes

## INT-399
- Changed JOP and FailOpen behavior.
  - When FAIL is selected for a JOP, the job is stopped.
  - When FAILURE is selected for a vulnerable application, the job is stopped.
  - This was done to be consistent with old behavior

## INT-398
- Fixed a bug where if FAILURE is selected for a vulnerable application and FAILOPEN checkbox is not selected, the build doesn't stop for pipeline step.

## INT-346
- Changed starDate to look at the time the job started instead of when the job was scheduled.