### PR TITLE
Move use of profile to after null check

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -331,13 +331,13 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         @Override
         public Void run() throws AbortException, InterruptedException {
             TeamServerProfile teamServerProfile = VulnerabilityTrendHelper.getProfile(step.getProfile());
-            final String CONTRAST_ERROR_PREFIX = teamServerProfile.isApplyVulnerableBuildResultOnContrastError() ? "Error: " : "Warning: ";
 
             if (teamServerProfile == null) {
                 VulnerabilityTrendHelper.logMessage(taskListener, "Unable to find TeamServer profile.");
                 throw new AbortException("Unable to find TeamServer profile.");
             }
 
+            final String CONTRAST_ERROR_PREFIX = teamServerProfile.isApplyVulnerableBuildResultOnContrastError() ? "Error: " : "Warning: ";
             ContrastSDK contrastSDK = VulnerabilityTrendHelper.createSDK(teamServerProfile.getUsername(), teamServerProfile.getServiceKey(),
                     teamServerProfile.getApiKey(), teamServerProfile.getTeamServerUrl());
 


### PR DESCRIPTION
If the wrong profile name is specified an NPE will occur as the profile is used before the null check. This change moves use of the profile back after the null check. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information
-->
