### PR TITLE
Int 605 fix issue in post build step where the global threshold is not used

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -206,7 +206,7 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
      * Background: Some configurations can make the Application ID to be stored as 'AppName (AppId)'
      * This is a getter that only returns the actual application id.
      * Returns a proper application Id.
-     * @return
+     * @return Returns the app id without the name attached
      */
     public String getPreparedApplicationId() {
         if (VulnerabilityTrendHelper.getAppIdFromAppTitle(applicationId) != null) {

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -192,10 +192,27 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
         }
 
         if(applicationId != null) {
-            sj.add("applicationId='"+applicationId+"'");
+            sj.add("applicationId='"+getPreparedApplicationId()+"'");
+        }
+
+        if(applicationId != null && applicationOriginName == null) {
+            sj.add(applicationId);
         }
 
         return preString + sj.toString() + postString;
+    }
+
+    /**
+     * Background: Some configurations can make the Application ID to be stored as 'AppName (AppId)'
+     * This is a getter that only returns the actual application id.
+     * Returns a proper application Id.
+     * @return
+     */
+    public String getPreparedApplicationId() {
+        if (VulnerabilityTrendHelper.getAppIdFromAppTitle(applicationId) != null) {
+            return VulnerabilityTrendHelper.getAppIdFromAppTitle(applicationId);
+        }
+        return applicationId;
     }
 
     /**

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -183,9 +183,20 @@ public class VulnerabilityTrendRecorder extends Recorder {
         return false;
     }
 
+    private boolean globalThresholdRequired(List<ThresholdCondition> conditions, ContrastSDK contrastSDK, TeamServerProfile profile)
+        throws IOException, UnauthorizedException {
+        for(ThresholdCondition condition : conditions) {
+            if((!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions)
+                && !VulnerabilityTrendHelper.isApplicableEnabledJobOutcomePolicyExist(contrastSDK, profile.getOrgUuid(), condition.getPreparedApplicationId())) {
+                    return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
-
+        boolean errorEncountered = false;
         if (!build.isBuilding()) {
             return false;
         }
@@ -203,6 +214,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
         final String CONTRAST_ERROR_PREFIX = profile.isApplyVulnerableBuildResultOnContrastError() ? "Error: " : "Warning: ";
 
         contrastSDK = VulnerabilityTrendHelper.createSDK(profile.getUsername(), profile.getServiceKey(), profile.getApiKey(), profile.getTeamServerUrl());
+
+
 
         try {
             final Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
@@ -222,16 +235,11 @@ public class VulnerabilityTrendRecorder extends Recorder {
         }
 
         boolean ignoreContrastFindings = Boolean.parseBoolean(build.getBuildVariableResolver().resolve("ignoreContrastFindings"));
-
         List<GlobalThresholdCondition> globalThresholdConditions = VulnerabilityTrendHelper.getGlobalThresholdConditions(profile.getName());
-
         List<ThresholdCondition> thresholdConditions = conditions;
 
-        // iterate over conditions; fail on first
+        // initialize app id in conditions
         for (ThresholdCondition condition : thresholdConditions) {
-
-
-            String appId = condition.getApplicationId();
             MatchBy matchBy = condition.getMatchBy() == null ? MatchBy.APPLICATION_ID : condition.getMatchBy();
             switch(matchBy){
                 case APPLICATION_ORIGIN_NAME:
@@ -249,31 +257,56 @@ public class VulnerabilityTrendRecorder extends Recorder {
                             if(updateBuildResult(build, profile, errorMessage)) {
                                 return true;
                             } else {
+                                errorEncountered = true;
                                 continue;
                             }
                         } else {
                             condition.setApplicationId(app.getId());
-                            appId = condition.getApplicationId();
-                            VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + appId + "]");
+                            VulnerabilityTrendHelper.logMessage(listener, "Fetched Application : [name = '" + condition.getApplicationOriginName() + "', displayName = '" + app.getName() + "', agentType='" + app.getLanguage() + "'] with ID: [" + condition.getPreparedApplicationId() + "]");
                         }
                     } catch (UnauthorizedException e) {
-                        String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve application information from TeamServer.";
+                        String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve application information from Contrast.";
                         VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                         VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
                         if(updateBuildResult(build, profile, errorMessage)) {
                             return true;
                         } else {
+                            errorEncountered = true;
                             continue;
                         }
                     }
                     break;
                 case APPLICATION_ID:
                 default:
-                    if (VulnerabilityTrendHelper.getAppIdFromAppTitle(appId) != null) {
-                        appId = VulnerabilityTrendHelper.getAppIdFromAppTitle(appId);
-                    }
                     break;
             }
+        }
+
+        try {
+            if (globalThresholdRequired(thresholdConditions, contrastSDK, profile)) {
+                thresholdConditions =
+                    VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+                if (thresholdConditions.isEmpty()) {
+                    String errorMessage = CONTRAST_ERROR_PREFIX + "Vulnerability Security Controls for connection '" + profile.getName() + "' are not defined.";
+                    VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+                    if(updateBuildResult(build, profile, errorMessage)) {
+                        return true;
+                    } else {
+                        errorEncountered = true;
+                    }
+                }
+            }
+        } catch (UnauthorizedException e) {
+            String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve job outcome policy information from Contrast";
+            VulnerabilityTrendHelper.logMessage(listener, errorMessage);
+            VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
+            updateBuildResult(build, profile, errorMessage);
+            return true;
+        }
+
+        // iterate over conditions; fail on first
+        for (ThresholdCondition condition : thresholdConditions) {
+            String appId = condition.getPreparedApplicationId();
 
             boolean applicationIdExists = VulnerabilityTrendHelper.applicationIdExists(contrastSDK, profile.getOrgUuid(), appId);
             if (!applicationIdExists) {
@@ -282,6 +315,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if(updateBuildResult(build, profile, errorMessage)) {
                     return true;
                 } else {
+                    errorEncountered = true;
                     continue;
                 }
             } else {
@@ -317,26 +351,12 @@ public class VulnerabilityTrendRecorder extends Recorder {
                                 if(updateBuildResult(build, profile, errorMessage)) {
                                     return true;
                                 } else {
+                                    errorEncountered = true;
                                     continue;
                                 }
                             }
                         }
                     } else {
-
-                        // if global threshold conditions cannot be overridden or the user does not want to override them
-                        if (!profile.isAllowGlobalThresholdConditionsOverride() || !overrideGlobalThresholdConditions) {
-                            thresholdConditions = VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
-                            if (thresholdConditions.isEmpty()) {
-                                String errorMessage = CONTRAST_ERROR_PREFIX + "Global Contrast Vulnerability Threshold Conditions for profile '" + profile.getName() + "' are not defined.";
-                                VulnerabilityTrendHelper.logMessage(listener, errorMessage);
-                                if(updateBuildResult(build, profile, errorMessage)) {
-                                    return true;
-                                } else {
-                                    continue;
-                                }
-                            }
-                        }
-
                         VulnerabilityTrendHelper.logMessage(listener, "filterForm: " + filterForm);
                         VulnerabilityTrendHelper.logMessage(listener, "Checking the threshold condition where " + condition.toString());
                         if (queryBy == Constants.QUERY_BY_START_DATE || queryBy == Constants.QUERY_BY_PARAMETER) {
@@ -369,6 +389,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     if(updateBuildResult(build, profile, errorMessage)) {
                         return true;
                     } else {
+                        errorEncountered = true;
                         continue;
                     }
 
@@ -376,10 +397,10 @@ public class VulnerabilityTrendRecorder extends Recorder {
             }
         }
 
-
         buildResult(resultTraces, build);
-
-        VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
+        if(!errorEncountered) {
+            VulnerabilityTrendHelper.logMessage(listener, "This build passes all vulnerability threshold conditions!");
+        }
 
         return true;
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -170,7 +170,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
      * @param message Message to log when status is failure
      * @return true = the result was set, false = the result was not set
      */
-    private boolean updateBuildResult(AbstractBuild<?, ?> build, TeamServerProfile profile, String message) throws AbortException {
+    private boolean updateBuildResultOnError(AbstractBuild<?, ?> build, TeamServerProfile profile, String message, BuildListener listener) throws AbortException {
         if(profile.isApplyVulnerableBuildResultOnContrastError()) {
             Result profileVulnerableBuildResult = Result.fromString(profile.getVulnerableBuildResult());
             if(Result.FAILURE.equals(profileVulnerableBuildResult)) {
@@ -179,6 +179,8 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 build.setResult(profileVulnerableBuildResult);
                 return true;
             }
+        } else {
+            VulnerabilityTrendHelper.logMessage(listener, "Warning: Build result was not updated because the connection "+profile.getName()+" is configured to not update the build status when an error occurs.");
         }
         return false;
     }
@@ -222,7 +224,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
             if (organizations == null || organizations.getOrganization() == null) {
                 String errorMessage = CONTRAST_ERROR_PREFIX + "No organization found, Check your credentials and URL.";
                 VulnerabilityTrendHelper.logMessage(listener, errorMessage);
-                updateBuildResult(build, profile, errorMessage);
+                updateBuildResultOnError(build, profile, errorMessage, listener);
                 return true;
             }
 
@@ -230,7 +232,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
             String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to connect to Contrast.";
             VulnerabilityTrendHelper.logMessage(listener, errorMessage);
             VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-            updateBuildResult(build, profile, errorMessage);
+            updateBuildResultOnError(build, profile, errorMessage, listener);
             return true;
         }
 
@@ -254,7 +256,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                                 throw new AbortException(errorMessage);
                             }
 
-                            if(updateBuildResult(build, profile, errorMessage)) {
+                            if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                                 return true;
                             } else {
                                 errorEncountered = true;
@@ -268,7 +270,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                         String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve application information from Contrast.";
                         VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                         VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                        if(updateBuildResult(build, profile, errorMessage)) {
+                        if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                             return true;
                         } else {
                             errorEncountered = true;
@@ -289,7 +291,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                 if (thresholdConditions.isEmpty()) {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Vulnerability Security Controls for connection '" + profile.getName() + "' are not defined.";
                     VulnerabilityTrendHelper.logMessage(listener, errorMessage);
-                    if(updateBuildResult(build, profile, errorMessage)) {
+                    if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                         return true;
                     } else {
                         errorEncountered = true;
@@ -300,7 +302,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
             String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve job outcome policy information from Contrast";
             VulnerabilityTrendHelper.logMessage(listener, errorMessage);
             VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-            updateBuildResult(build, profile, errorMessage);
+            updateBuildResultOnError(build, profile, errorMessage, listener);
             return true;
         }
 
@@ -312,7 +314,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
             if (!applicationIdExists) {
                 String errorMessage = CONTRAST_ERROR_PREFIX + "Application with ID '" + appId + "' not found.";
                 VulnerabilityTrendHelper.logMessage(listener, CONTRAST_ERROR_PREFIX + "Application with ID '" + appId + "' not found.");
-                if(updateBuildResult(build, profile, errorMessage)) {
+                if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                     return true;
                 } else {
                     errorEncountered = true;
@@ -348,7 +350,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                                 String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve outcome from job outcome policy";
                                 VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                                 VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                                if(updateBuildResult(build, profile, errorMessage)) {
+                                if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                                     return true;
                                 } else {
                                     errorEncountered = true;
@@ -386,7 +388,7 @@ public class VulnerabilityTrendRecorder extends Recorder {
                     String errorMessage = CONTRAST_ERROR_PREFIX + "Unable to retrieve vulnerability information from TeamServer.";
                     VulnerabilityTrendHelper.logMessage(listener, errorMessage);
                     VulnerabilityTrendHelper.logMessage(listener, e.getMessage());
-                    if(updateBuildResult(build, profile, errorMessage)) {
+                    if(updateBuildResultOnError(build, profile, errorMessage, listener)) {
                         return true;
                     } else {
                         errorEncountered = true;

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -1,5 +1,6 @@
 package com.aspectsecurity.contrast.contrastjenkins;
 
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Application;
@@ -32,6 +33,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,6 +47,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, VulnerabilityTrendRecorder.class, VulnerabilityTrendHelper.class})
@@ -710,6 +713,76 @@ public class VulnerabilityTrendRecorderTest {
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
         verify(build, never()).setResult(Result.fromString(profileMock.getVulnerableBuildResult()));
+    }
+
+    @Test
+    public void testGlobalThresholdUsedWhenNotOverridden()
+        throws IOException, UnauthorizedException, InterruptedException {
+        List<ThresholdCondition> conditions = new ArrayList<>();
+        final int buildNumber = 1;
+        final String buildParentFullName = "Project";
+
+        //a condition without any thresholds
+        ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
+        when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
+
+        conditions.add(defaultThresholdCondition);
+
+        //a global condition
+        GlobalThresholdCondition globalThresholdCondition = mock(GlobalThresholdCondition.class);
+        List<GlobalThresholdCondition> globalThresholdConditions = new ArrayList<>();
+        globalThresholdConditions.add(globalThresholdCondition);
+
+        given(VulnerabilityTrendHelper.getGlobalThresholdConditions(anyString())).willReturn(globalThresholdConditions);
+
+
+        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
+        given(VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions)).willReturn(Lists.newArrayList());
+
+        VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
+            "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
+
+        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+
+        ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
+        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+
+        TeamServerProfile profileMock = mock(TeamServerProfile.class);
+        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
+        when(profileMock.isApplyVulnerableBuildResultOnContrastError()).thenReturn(true);
+        when(profileMock.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
+
+        SecurityCheck securityCheckMock = mock(SecurityCheck.class);
+        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).thenReturn(securityCheckMock);
+        when(securityCheckMock.getResult()).thenReturn(null);
+
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        AbstractProject<?, ?> parent = mock(AbstractProject.class);
+
+        ItemGroup itemGroup = mock(ItemGroup.class);
+        when(itemGroup.getFullName()).thenReturn("");
+        when(parent.getParent()).thenReturn(itemGroup);
+
+        when(parent.getFullName()).thenReturn(buildParentFullName);
+
+        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+
+        Launcher launcher = mock(Launcher.class);
+        BuildListener listener = mock(BuildListener.class);
+
+        when(build.isBuilding()).thenReturn(true);
+        when(build.getNumber()).thenReturn(buildNumber);
+
+        Organizations mockOrgs = mock(Organizations.class);
+        Organization mockOrg = mock(Organization.class);
+        when(mockOrgs.getOrganization()).thenReturn(mockOrg);
+        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+
+        vulnerabilityTrendRecorder.perform(build, launcher, listener);
+        verifyStatic();
+        VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
     }
 
 }


### PR DESCRIPTION
Fixes an issue in the post build step where the global threshold is not used.
Moved around the preparation and validations done within the main loop to more concise portions.
Moved extraction of the application id from the stored name and application id combination to the threshold class.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
