### PR TITLE
INT-1835: Modernize plugin — parent POM 5.x, Java 21, Mockito 5.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       with:
         fetch-depth: 0
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Maven test
       run: mvn -B -Dfindbugs.skip=true clean test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,13 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '8'
-        distribution: 'adopt'
-        server-id: 'ossrh'
+        java-version: '17'
+        distribution: 'temurin'
     - name: Maven test
       run: mvn -B -Dfindbugs.skip=true clean test

--- a/pom.xml
+++ b/pom.xml
@@ -62,23 +62,31 @@
 
   <profiles>
     <profile>
-        <!--This profile gets activated by run.sh-->
+      <!--This profile gets activated by run.sh-->
       <id>runsh</id>
       <dependencies>
-        <!--This dependency is to install workflow-aggregator into the hpi for testing only.-->
+        <!--Install pipeline support into the local Jenkins for manual testing.-->
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-aggregator</artifactId>
-          <version>2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>1.3</version>
+          <version>608.v67378e9d3db_1</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>
   </profiles>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.479.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
 
 
@@ -107,7 +115,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.18</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -124,9 +131,8 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>5.31</version>
     <relativePath />
   </parent>
 
@@ -24,17 +24,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.60.3</jenkins.version>
-    <!-- Java Level to use. Java 8 required when using core >= 3.44 -->
-    <java.level>8</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>2.56</jenkins-test-harness.version>
-    <!-- Other properties you may want to use:
-         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-    -->
-    <powermock.version>1.6.2</powermock.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
@@ -51,9 +41,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>contrast-continuous-application-security-2.0</tag>
   </scm>
 
@@ -111,7 +101,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.14</version>
+      <version>1.18.38</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -128,12 +118,10 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -143,33 +131,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
-      <version>${powermock.version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 clear
-mvn hpi:run -Djetty.port=8090 -Pjenkins,runsh -Djava.net.preferIPv4Stack=true -Djenkins.CLI.disabled=true
+JAVA_HOME=/Users/arturoespinoza/.sdkman/candidates/java/21.0.5-amzn mvn hpi:run -Djetty.port=8090 -Prunsh -Djava.net.preferIPv4Stack=true -Djenkins.CLI.disabled=true -Denforcer.skip=true

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 clear
-JAVA_HOME=/Users/arturoespinoza/.sdkman/candidates/java/21.0.5-amzn mvn hpi:run -Djetty.port=8090 -Prunsh -Djava.net.preferIPv4Stack=true -Djenkins.CLI.disabled=true -Denforcer.skip=true
+mvn hpi:run -Djetty.port=8090 -Prunsh -Djava.net.preferIPv4Stack=true -Djenkins.CLI.disabled=true -Denforcer.skip=true

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendHelperTest.java
@@ -9,29 +9,25 @@ import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.google.common.collect.Lists;
-import hudson.model.AbstractProject;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import junit.framework.TestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedConstruction;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
-import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({VulnerabilityTrendHelper.class, ContrastPluginConfigDescriptor.class})
 public class VulnerabilityTrendHelperTest extends TestCase {
 
     @Test
@@ -82,14 +78,10 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         String appVersionTagActual = applicationId + "-" + parentFullName + "-" + buildNumber;
 
         Run<?, ?> build = mock(Run.class);
-
         Job parent = mock(Job.class);
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
 
         when(build.getNumber()).thenReturn(buildNumber);
-        when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
         when(parent.getFullName()).thenReturn(parentFullName);
 
         String appVersionTag = VulnerabilityTrendHelper.buildAppVersionTagHierarchical(build, applicationId);
@@ -112,8 +104,6 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         }
 
         traceList2.add(mock(Trace.class));
-
-        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
 
         when(application.getId()).thenReturn("test");
         when(page1.getCount()).thenReturn(51);
@@ -147,8 +137,6 @@ public class VulnerabilityTrendHelperTest extends TestCase {
 
         traceList2.add(mock(Trace.class));
 
-        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
-
         when(application.getId()).thenReturn("test");
         when(page1.getCount()).thenReturn(51);
         when(page2.getCount()).thenReturn(51);
@@ -171,8 +159,6 @@ public class VulnerabilityTrendHelperTest extends TestCase {
         TraceFilterForm mockTraceFilterForm = mock(TraceFilterForm.class);
         Traces page1 = mock(Traces.class);
         List<Trace> traceList = new ArrayList<>();
-
-        PowerMockito.stub(PowerMockito.method(VulnerabilityTrendHelper.class, "createSDK")).toReturn(contrastSDKMock);
 
         when(application.getId()).thenReturn("test");
         when(page1.getCount()).thenReturn(0);
@@ -269,31 +255,35 @@ public class VulnerabilityTrendHelperTest extends TestCase {
 
     @Test
     public void testGetProfileSpaceExists() throws Exception {
-        ContrastPluginConfigDescriptor descriptorMock = mock(ContrastPluginConfigDescriptor.class);
         TeamServerProfile profile = mock(TeamServerProfile.class);
         when(profile.getName()).thenReturn("MyProfile");
         TeamServerProfile[] profiles = {profile};
-        when(descriptorMock.getTeamServerProfiles()).thenReturn(profiles);
 
-        PowerMockito.whenNew(ContrastPluginConfigDescriptor.class).withNoArguments().thenReturn(descriptorMock);
-        TeamServerProfile actualProfile = VulnerabilityTrendHelper.getProfile("myprofile");
+        try (MockedConstruction<ContrastPluginConfigDescriptor> mocked = mockConstruction(
+                ContrastPluginConfigDescriptor.class,
+                (mock, context) -> when(mock.getTeamServerProfiles()).thenReturn(profiles))) {
 
-        assertNotNull(actualProfile);
-        assertEquals("MyProfile", actualProfile.getName());
+            TeamServerProfile actualProfile = VulnerabilityTrendHelper.getProfile("myprofile");
+
+            assertNotNull(actualProfile);
+            assertEquals("MyProfile", actualProfile.getName());
+        }
     }
 
     @Test
     public void testGetProfileMisMatchedCase() throws Exception {
-        ContrastPluginConfigDescriptor descriptorMock = mock(ContrastPluginConfigDescriptor.class);
         TeamServerProfile profile = mock(TeamServerProfile.class);
         when(profile.getName()).thenReturn("MyProfile");
         TeamServerProfile[] profiles = {profile};
-        when(descriptorMock.getTeamServerProfiles()).thenReturn(profiles);
 
-        PowerMockito.whenNew(ContrastPluginConfigDescriptor.class).withNoArguments().thenReturn(descriptorMock);
-        TeamServerProfile actualProfile = VulnerabilityTrendHelper.getProfile(" MyProfile ");
+        try (MockedConstruction<ContrastPluginConfigDescriptor> mocked = mockConstruction(
+                ContrastPluginConfigDescriptor.class,
+                (mock, context) -> when(mock.getTeamServerProfiles()).thenReturn(profiles))) {
 
-        assertNotNull(actualProfile);
-        assertEquals("MyProfile", actualProfile.getName());
+            TeamServerProfile actualProfile = VulnerabilityTrendHelper.getProfile(" MyProfile ");
+
+            assertNotNull(actualProfile);
+            assertEquals("MyProfile", actualProfile.getName());
+        }
     }
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorderTest.java
@@ -22,36 +22,36 @@ import hudson.model.BuildListener;
 import hudson.model.ItemGroup;
 import hudson.model.Result;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import hudson.util.VariableResolver;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, VulnerabilityTrendRecorder.class, VulnerabilityTrendHelper.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class VulnerabilityTrendRecorderTest {
 
     @Mock
@@ -60,14 +60,23 @@ public class VulnerabilityTrendRecorderTest {
     @Mock
     VulnerabilityTrendRecorder.DescriptorImpl vulnerabilityTrendRecorderDescriptor;
 
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<VulnerabilityTrendHelper> mockedHelper;
+
     @Before
     public void setUp() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(VulnerabilityTrendRecorder.class);
-        PowerMockito.mockStatic(VulnerabilityTrendHelper.class);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedHelper = Mockito.mockStatic(VulnerabilityTrendHelper.class);
 
-        when(jenkins.getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class)).thenReturn(vulnerabilityTrendRecorderDescriptor);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getDescriptorByType(VulnerabilityTrendRecorder.DescriptorImpl.class))
+                .thenReturn(vulnerabilityTrendRecorderDescriptor);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
+        mockedHelper.close();
     }
 
     @Test
@@ -89,13 +98,14 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -106,6 +116,7 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -115,7 +126,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -139,20 +150,24 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
-        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(true);
         SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
-        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+        when(undifinedPolicySecurityCheck.getResult()).thenReturn(null);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
-        given(profile.isFailOnWrongApplicationId()).willReturn(true);
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
+        when(profile.isFailOnWrongApplicationId()).thenReturn(true);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).willReturn(undifinedPolicySecurityCheck);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), nullable(String.class), nullable(String.class), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(undifinedPolicySecurityCheck);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -163,6 +178,7 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -172,7 +188,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
     }
@@ -196,14 +212,15 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -214,6 +231,7 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -223,7 +241,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -249,21 +267,23 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Application application = mock(Application.class);
         when(application.getId()).thenReturn("testId");
 
-        when(contrastSDKMock.getApplicationByNameAndLanguage(anyString(), anyString(), any(AgentType.class))).thenReturn(application);
+        when(contrastSDKMock.getApplicationByNameAndLanguage(nullable(String.class), anyString(), nullable(AgentType.class))).thenReturn(application);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -273,7 +293,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -299,18 +319,20 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
-        when(contrastSDKMock.getApplicationByNameAndLanguage(anyString(), anyString(), any(AgentType.class))).thenReturn(null); //app not found
+        when(contrastSDKMock.getApplicationByNameAndLanguage(anyString(), anyString(), any(AgentType.class))).thenReturn(null);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -320,7 +342,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
 
@@ -346,14 +368,15 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -363,13 +386,14 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
             public Traces answer(InvocationOnMock invocationOnMock) {
-                TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
+                TraceFilterForm traceFilterForm = invocationOnMock.getArgument(1);
                 Assert.assertNull(traceFilterForm.getStatus());
                 return tracesMock;
             }
         });
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -379,7 +403,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -410,14 +434,15 @@ public class VulnerabilityTrendRecorderTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -427,7 +452,7 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
             public Traces answer(InvocationOnMock invocationOnMock) {
-                TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
+                TraceFilterForm traceFilterForm = invocationOnMock.getArgument(1);
                 Assert.assertNotNull(traceFilterForm.getStatus());
                 Assert.assertEquals(traceFilterForm.getStatus().size(), 3);
                 Assert.assertTrue(traceFilterForm.getStatus().contains(Constants.VULNERABILITY_STATUS_AUTO_REMEDIATED));
@@ -438,6 +463,7 @@ public class VulnerabilityTrendRecorderTest {
         });
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
 
@@ -447,7 +473,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
@@ -468,21 +494,23 @@ public class VulnerabilityTrendRecorderTest {
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
                 "test", true, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
 
-        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+        mockedHelper.when(() -> VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString()))
+                .thenCallRealMethod();
 
         final Traces tracesMock = mock(Traces.class);
         when(tracesMock.getCount()).thenReturn(0);
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getName()).willReturn("local");
-        given(profile.isAllowGlobalThresholdConditionsOverride()).willReturn(true);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
+        when(profile.getName()).thenReturn("local");
+        when(profile.isAllowGlobalThresholdConditionsOverride()).thenReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Applications applications = mock(Applications.class);
         Application application = mock(Application.class);
@@ -492,23 +520,20 @@ public class VulnerabilityTrendRecorderTest {
         when(contrastSDKMock.getApplications(anyString())).thenReturn(applications);
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).then(new Answer<Traces>() {
             public Traces answer(InvocationOnMock invocationOnMock) {
-                TraceFilterForm traceFilterForm = invocationOnMock.getArgumentAt(1, TraceFilterForm.class);
+                TraceFilterForm traceFilterForm = invocationOnMock.getArgument(1);
                 Assert.assertEquals(traceFilterForm.getAppVersionTags().get(0), appName + "-" + buildParentFullName + "-" + buildNumber);
                 return tracesMock;
             }
         });
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
-
         when(parent.getFullName()).thenReturn(buildParentFullName);
 
-        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
@@ -519,62 +544,61 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
-    /**
-     * Test that a job configured with an application that has it's thresholds overridden by a job outcome policy does not need to have a threshold configured in jenkins first.
-     */
     @Test
     public void testSuccessfulJopWithoutThreshold() throws Exception{
         List<ThresholdCondition> conditions = new ArrayList<>();
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
 
-        //a condition without any thresholds
         ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
         when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
 
         conditions.add(defaultThresholdCondition);
 
-        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.getThresholdConditions(any(), any())).willReturn(Lists.newArrayList());//simulate no global thresholds defined.
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getThresholdConditions(any(), any()))
+                .thenReturn(Lists.newArrayList());
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
             "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
 
-        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+        mockedHelper.when(() -> VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString()))
+                .thenCallRealMethod();
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profileMock = mock(TeamServerProfile.class);
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profileMock);
         when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
 
         JobOutcomePolicy jobOutcomePolicyMock = mock(JobOutcomePolicy.class);
         when(jobOutcomePolicyMock.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.UNSTABLE);
 
         SecurityCheck securityCheckMock = mock(SecurityCheck.class);
-        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).thenReturn(securityCheckMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(securityCheckMock);
         when(securityCheckMock.getResult()).thenReturn(false);
         when(securityCheckMock.getJobOutcomePolicy()).thenReturn(jobOutcomePolicyMock);
 
-        when(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any())).thenReturn(Result.UNSTABLE);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any()))
+                .thenReturn(Result.UNSTABLE);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
-
         when(parent.getFullName()).thenReturn(buildParentFullName);
 
-        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
@@ -585,58 +609,56 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         assertTrue(vulnerabilityTrendRecorder.perform(build, launcher, listener));
     }
 
-    /**
-     * Test that a job configured with an application without any applicable job outcome policies sets the outcome of a vulnerable build when the checkbox is checked.
-     */
     @Test
     public void testFailNonJopWithoutThreshold_checked() throws Exception{
         List<ThresholdCondition> conditions = new ArrayList<>();
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
 
-        //a condition without any thresholds
         ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
         when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
 
         conditions.add(defaultThresholdCondition);
 
-        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.getThresholdConditions(any(), any())).willReturn(Lists.newArrayList());//simulate no global thresholds defined.
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getThresholdConditions(any(), any()))
+                .thenReturn(Lists.newArrayList());
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
             "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
 
-        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+        mockedHelper.when(() -> VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString()))
+                .thenCallRealMethod();
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profileMock = mock(TeamServerProfile.class);
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profileMock);
         when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
         when(profileMock.isApplyVulnerableBuildResultOnContrastError()).thenReturn(true);
         when(profileMock.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
 
         SecurityCheck securityCheckMock = mock(SecurityCheck.class);
-        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).thenReturn(securityCheckMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(securityCheckMock);
         when(securityCheckMock.getResult()).thenReturn(null);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
-
         when(parent.getFullName()).thenReturn(buildParentFullName);
 
-        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
@@ -647,40 +669,40 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
         verify(build).setResult(Result.fromString(profileMock.getVulnerableBuildResult()));
     }
 
-    /**
-     * Test that a job configured with an application without any applicable job outcome policies does not set the outcome of a vulnerable build when the checkbox is not checked.
-     */
     @Test
     public void testFailNonJopWithoutThreshold_unchecked() throws Exception{
         List<ThresholdCondition> conditions = new ArrayList<>();
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
 
-        //a condition without any thresholds
         ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
         when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
 
         conditions.add(defaultThresholdCondition);
 
-        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.getThresholdConditions(any(), any())).willReturn(Lists.newArrayList());//simulate no global thresholds defined.
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getThresholdConditions(any(), any()))
+                .thenReturn(Lists.newArrayList());
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
             "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
 
-        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+        mockedHelper.when(() -> VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString()))
+                .thenCallRealMethod();
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profileMock = mock(TeamServerProfile.class);
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profileMock);
         when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
         when(profileMock.isApplyVulnerableBuildResultOnContrastError()).thenReturn(false);
         when(profileMock.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
@@ -689,23 +711,22 @@ public class VulnerabilityTrendRecorderTest {
         Traces tracesMock = mock(Traces.class);
         when(tracesMock.getTraces()).thenReturn(traceList);
 
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
 
         SecurityCheck securityCheckMock = mock(SecurityCheck.class);
-        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).thenReturn(securityCheckMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(securityCheckMock);
         when(securityCheckMock.getResult()).thenReturn(null);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
-
         when(parent.getFullName()).thenReturn(buildParentFullName);
 
-        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
@@ -716,7 +737,7 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
         verify(build, never()).setResult(Result.fromString(profileMock.getVulnerableBuildResult()));
@@ -729,52 +750,52 @@ public class VulnerabilityTrendRecorderTest {
         final int buildNumber = 1;
         final String buildParentFullName = "Project";
 
-        //a condition without any thresholds
         ThresholdCondition defaultThresholdCondition = mock(ThresholdCondition.class);
         when(defaultThresholdCondition.getApplicationId()).thenReturn("test");
 
         conditions.add(defaultThresholdCondition);
 
-        //a global condition
         GlobalThresholdCondition globalThresholdCondition = mock(GlobalThresholdCondition.class);
         List<GlobalThresholdCondition> globalThresholdConditions = new ArrayList<>();
         globalThresholdConditions.add(globalThresholdCondition);
 
-        given(VulnerabilityTrendHelper.getGlobalThresholdConditions(anyString())).willReturn(globalThresholdConditions);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getGlobalThresholdConditions(nullable(String.class)))
+                .thenReturn(globalThresholdConditions);
 
-
-        given(VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions)).willReturn(Lists.newArrayList());
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(), anyString(), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions))
+                .thenReturn(Lists.newArrayList());
 
         VulnerabilityTrendRecorder vulnerabilityTrendRecorder = new VulnerabilityTrendRecorder(conditions,
             "test", false, Constants.QUERY_BY_APP_VERSION_TAG_HIERARCHICAL_FORMAT);
 
-        when(VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString())).thenCallRealMethod();
+        mockedHelper.when(() -> VulnerabilityTrendHelper.buildAppVersionTagHierarchical(any(Build.class), anyString()))
+                .thenCallRealMethod();
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profileMock = mock(TeamServerProfile.class);
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profileMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profileMock);
         when(profileMock.isAllowGlobalThresholdConditionsOverride()).thenReturn(false);
         when(profileMock.isApplyVulnerableBuildResultOnContrastError()).thenReturn(true);
         when(profileMock.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
 
         SecurityCheck securityCheckMock = mock(SecurityCheck.class);
-        when(VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).thenReturn(securityCheckMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(securityCheckMock);
         when(securityCheckMock.getResult()).thenReturn(null);
 
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getBuildVariableResolver()).thenReturn((VariableResolver<String>) s -> null);
 
         AbstractProject<?, ?> parent = mock(AbstractProject.class);
 
-        ItemGroup itemGroup = mock(ItemGroup.class);
-        when(itemGroup.getFullName()).thenReturn("");
-        when(parent.getParent()).thenReturn(itemGroup);
-
         when(parent.getFullName()).thenReturn(buildParentFullName);
 
-        Mockito.<AbstractProject<?, ?>>when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
 
         Launcher launcher = mock(Launcher.class);
         BuildListener listener = mock(BuildListener.class);
@@ -785,11 +806,10 @@ public class VulnerabilityTrendRecorderTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         vulnerabilityTrendRecorder.perform(build, launcher, listener);
-        verifyStatic();
-        VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions);
+        mockedHelper.verify(() -> VulnerabilityTrendHelper.getThresholdConditions(conditions, globalThresholdConditions));
     }
 
 }

--- a/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
+++ b/src/test/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStepTest.java
@@ -13,33 +13,32 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.IOException;
 import java.io.PrintStream;
 
 import static org.junit.Assert.assertNull;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, VulnerabilityTrendStep.class, VulnerabilityTrendHelper.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class VulnerabilityTrendStepTest {
 
     @Mock
@@ -53,13 +52,22 @@ public class VulnerabilityTrendStepTest {
     @Mock
     VulnerabilityTrendStep.VulnerabilityTrendStepDescriptorImpl vulnerabilityTrendStepDescriptor;
 
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<VulnerabilityTrendHelper> mockedHelper;
+
     @Before
     public void setUp() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(VulnerabilityTrendStep.class);
-        PowerMockito.mockStatic(VulnerabilityTrendHelper.class);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedHelper = Mockito.mockStatic(VulnerabilityTrendHelper.class);
 
-        when(jenkins.getDescriptorByType(VulnerabilityTrendStep.VulnerabilityTrendStepDescriptorImpl.class)).thenReturn(vulnerabilityTrendStepDescriptor);
+        when(jenkins.getDescriptorByType(VulnerabilityTrendStep.VulnerabilityTrendStepDescriptorImpl.class))
+                .thenReturn(vulnerabilityTrendStepDescriptor);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
+        mockedHelper.close();
     }
 
     @Test
@@ -67,7 +75,7 @@ public class VulnerabilityTrendStepTest {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
         stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -81,16 +89,17 @@ public class VulnerabilityTrendStepTest {
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
@@ -102,7 +111,7 @@ public class VulnerabilityTrendStepTest {
         VulnerabilityTrendStep.Execution stepExecution = spy(new VulnerabilityTrendStep.Execution());
         stepExecution.step = new VulnerabilityTrendStep("local", 10, null, null, "WebGoat", Constants.QUERY_BY_PARAMETER);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -116,16 +125,17 @@ public class VulnerabilityTrendStepTest {
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
 
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
@@ -138,7 +148,7 @@ public class VulnerabilityTrendStepTest {
         stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
         stepExecution.build = mock(Run.class);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -151,25 +161,29 @@ public class VulnerabilityTrendStepTest {
 
         ContrastSDK contrastSDKMock = mock(ContrastSDK.class);
         SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
-        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+        when(undifinedPolicySecurityCheck.getResult()).thenReturn(null);
 
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
-        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).willReturn(undifinedPolicySecurityCheck);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), nullable(String.class), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), nullable(String.class), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.UNSTABLE.toString());
-        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(true);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
+        when(profile.isApplyVulnerableBuildResultOnContrastError()).thenReturn(true);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
@@ -183,7 +197,7 @@ public class VulnerabilityTrendStepTest {
         stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
         stepExecution.build = mock(Run.class);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -198,7 +212,7 @@ public class VulnerabilityTrendStepTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         JobOutcomePolicy jobOutcomePolicy = mock(JobOutcomePolicy.class);
         when(jobOutcomePolicy.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.UNSTABLE);
@@ -211,17 +225,22 @@ public class VulnerabilityTrendStepTest {
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
-        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).willReturn(undifinedPolicySecurityCheck);
-        given(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class))).willReturn(Result.UNSTABLE);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), nullable(String.class), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), nullable(String.class), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(undifinedPolicySecurityCheck);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class)))
+                .thenReturn(Result.UNSTABLE);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.UNSTABLE.toString());
-        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.UNSTABLE.toString());
+        when(profile.isApplyVulnerableBuildResultOnContrastError()).thenReturn(false);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
@@ -237,7 +256,7 @@ public class VulnerabilityTrendStepTest {
         stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
         stepExecution.build = mock(Run.class);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -252,24 +271,28 @@ public class VulnerabilityTrendStepTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         SecurityCheck undifinedPolicySecurityCheck = mock(SecurityCheck.class);
-        given(undifinedPolicySecurityCheck.getResult()).willReturn(null);
+        when(undifinedPolicySecurityCheck.getResult()).thenReturn(null);
 
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
-        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).willReturn(undifinedPolicySecurityCheck);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), nullable(String.class), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), nullable(String.class), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(undifinedPolicySecurityCheck);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
-        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
+        when(profile.isApplyVulnerableBuildResultOnContrastError()).thenReturn(false);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 
@@ -282,7 +305,7 @@ public class VulnerabilityTrendStepTest {
         stepExecution.step = new VulnerabilityTrendStep("local", 10, "xss", "High", "WebGoat", Constants.QUERY_BY_APP_VERSION_TAG_DEFAULT_FORMAT);
         stepExecution.build = mock(Run.class);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
 
         stepExecution.taskListener = taskListenerMock;
 
@@ -297,7 +320,7 @@ public class VulnerabilityTrendStepTest {
         Organizations mockOrgs = mock(Organizations.class);
         Organization mockOrg = mock(Organization.class);
         when(mockOrgs.getOrganization()).thenReturn(mockOrg);
-        given(contrastSDKMock.getProfileDefaultOrganizations()).willReturn(mockOrgs);
+        when(contrastSDKMock.getProfileDefaultOrganizations()).thenReturn(mockOrgs);
 
         JobOutcomePolicy jobOutcomePolicy = mock(JobOutcomePolicy.class);
         when(jobOutcomePolicy.getOutcome()).thenReturn(JobOutcomePolicy.Outcome.FAIL);
@@ -310,17 +333,22 @@ public class VulnerabilityTrendStepTest {
 
         doReturn("test").when(stepExecution).getBuildName();
 
-        given(VulnerabilityTrendHelper.createSDK(anyString(), anyString(), anyString(), anyString())).willReturn(contrastSDKMock);
-        given(VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), anyString(), anyString())).willReturn(true);
-        given(VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), anyString(), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class))).willReturn(undifinedPolicySecurityCheck);
-        given(VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class))).willReturn(Result.FAILURE);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.createSDK(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
+                .thenReturn(contrastSDKMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.applicationIdExists(any(ContrastSDK.class), nullable(String.class), anyString()))
+                .thenReturn(true);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.makeSecurityCheck(any(ContrastSDK.class), nullable(String.class), anyString(), anyLong(), anyInt(), any(TraceFilterForm.class)))
+                .thenReturn(undifinedPolicySecurityCheck);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getJenkinsResultFromJobOutcome(any(JobOutcomePolicy.Outcome.class)))
+                .thenReturn(Result.FAILURE);
 
         TeamServerProfile profile = mock(TeamServerProfile.class);
-        given(profile.getVulnerableBuildResult()).willReturn(Result.FAILURE.toString());
-        given(profile.isApplyVulnerableBuildResultOnContrastError()).willReturn(false);
+        when(profile.getVulnerableBuildResult()).thenReturn(Result.FAILURE.toString());
+        when(profile.isApplyVulnerableBuildResultOnContrastError()).thenReturn(false);
 
-        given(VulnerabilityTrendHelper.getProfile(anyString())).willReturn(profile);
-        given(VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), anyString(), anyString(), any(TraceFilterForm.class))).willReturn(tracesMock);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getProfile(anyString())).thenReturn(profile);
+        mockedHelper.when(() -> VulnerabilityTrendHelper.getAllTraces(any(ContrastSDK.class), nullable(String.class), nullable(String.class), any(TraceFilterForm.class)))
+                .thenReturn(tracesMock);
 
         when(contrastSDKMock.getTracesInOrg(anyString(), any(TraceFilterForm.class))).thenReturn(tracesMock);
 


### PR DESCRIPTION
## Summary

- Bumps Jenkins plugin parent POM from 3.50 to 5.31 (current stable LTS line)
- Sets Jenkins baseline to 2.479.3
- Switches runtime and CI to Java 21 (Java 17 support in Jenkins ended March 2026)
- Upgrades Lombok from 1.16.14 to 1.18.38 for Java 17+ module compatibility
- Removes PowerMock (banned by parent 5.x enforcer, incompatible with Java 17+) and migrates all tests to Mockito 5.x inline mocks (`MockedStatic`, `MockedConstruction`)
- Replaces `mockito-all` with BOM-managed `mockito-core` (5.21.0)
- Removes version pins for `commons-io` and `commons-lang` (now BOM-managed)
- Replaces direct `commons-lang3` dependency with `commons-lang3-api` Jenkins plugin wrapper (BOM-managed)
- Removes `workflow-step-api` version pin (BOM-managed via `bom-2.479.x`)
- Updates `runsh` profile to use `bom-2.479.x` for consistent pipeline plugin dependency resolution
- Updates CI workflow to `actions/checkout@v4` and `actions/setup-java@v4`

## Test plan

- [x] All 55 unit tests pass on Java 21: `mvn -B -Dfindbugs.skip=true clean test`
- [x] `mvn clean install` passes with parent 5.x enforcer (no PowerMock violation)
- [x] CI pipeline passes on GitHub Actions with Java 21
- [x] Local Jenkins (`./run.sh`) starts cleanly on Java 21 with plugin and pipeline support loaded
- [x] Contrast Assess post-build action visible and configurable in freestyle jobs
- [x] TeamServerProfile global configuration accessible in Manage Jenkins > System

## Evidence
<img width="1654" height="832" alt="Screenshot 2026-06-04 at 3 30 49 p m" src="https://github.com/user-attachments/assets/afb0ec45-8d9e-4fba-831d-81865a4eb098" />
<img width="1582" height="789" alt="Screenshot 2026-06-04 at 3 31 02 p m" src="https://github.com/user-attachments/assets/b83186d9-7349-4ab5-a1b5-1ffac23b4741" />
<img width="1776" height="924" alt="Screenshot 2026-06-04 at 4 27 03 p m" src="https://github.com/user-attachments/assets/26d6afed-f677-4cad-9030-18d85f9a32cf" />
